### PR TITLE
feat(editor): scheduledAt date picker + postId display + tac post new/schedule

### DIFF
--- a/backend/src/TacBlog.Api/Endpoints/LocalEndpoints.cs
+++ b/backend/src/TacBlog.Api/Endpoints/LocalEndpoints.cs
@@ -1,0 +1,27 @@
+namespace TacBlog.Api.Endpoints;
+
+public static class LocalEndpoints
+{
+    public static IEndpointRouteBuilder MapLocalEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPut("/local/file", async (SaveFileRequest req) =>
+        {
+            if (!req.FilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+                return Results.BadRequest("Only .md files are allowed.");
+
+            if (req.FilePath.Contains(".."))
+                return Results.BadRequest("Path traversal is not allowed.");
+
+            if (!File.Exists(req.FilePath))
+                return Results.NotFound("File not found. Will not create new files via this endpoint.");
+
+            await File.WriteAllTextAsync(req.FilePath, req.Content);
+            return Results.Ok();
+        })
+        .AddEndpointFilter<AdminApiKeyFilter>();
+
+        return app;
+    }
+}
+
+record SaveFileRequest(string FilePath, string Content);

--- a/backend/src/TacBlog.Api/Program.cs
+++ b/backend/src/TacBlog.Api/Program.cs
@@ -165,6 +165,9 @@ app.MapLikeEndpoints();
 app.MapCommentEndpoints();
 app.MapOAuthEndpoints();
 
+if (app.Environment.IsDevelopment())
+    app.MapLocalEndpoints();
+
 app.Run();
 
 public partial class Program;

--- a/backend/src/TacBlog.Cli/Commands/PostCommands.cs
+++ b/backend/src/TacBlog.Cli/Commands/PostCommands.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Text.RegularExpressions;
 
 namespace TacBlog.Cli.Commands;
 
@@ -8,9 +9,11 @@ public static class PostCommands
     {
         var postCmd = new Command("post", "Manage blog posts");
 
+        postCmd.AddCommand(BuildNew(urlOpt, keyOpt));
         postCmd.AddCommand(BuildCreate(urlOpt, keyOpt));
         postCmd.AddCommand(BuildList(urlOpt, keyOpt));
         postCmd.AddCommand(BuildPublish(urlOpt, keyOpt));
+        postCmd.AddCommand(BuildSchedule(urlOpt, keyOpt));
         postCmd.AddCommand(BuildArchive(urlOpt, keyOpt));
         postCmd.AddCommand(BuildRestore(urlOpt, keyOpt));
         postCmd.AddCommand(BuildDelete(urlOpt, keyOpt));
@@ -21,8 +24,9 @@ public static class PostCommands
     private static Command BuildCreate(Option<string> urlOpt, Option<string> keyOpt)
     {
         var cmd = new Command("create", "Create a new post");
-        var titleOpt = new Option<string>("--title", "Post title") { IsRequired = true };
-        var contentOpt = new Option<FileInfo?>("--content", "Path to markdown file");
+        var titleOpt = new Option<string?>("--title", "Post title");
+        var contentOpt = new Option<FileInfo?>("--content", "Path to markdown file (raw content, no frontmatter)");
+        var fileOpt = new Option<FileInfo?>("--file", "Path to markdown file with YAML frontmatter");
         var draftOpt = new Option<bool>("--draft", "Save as draft without publishing");
         var tagsOpt = new Option<string[]>("--tag", "Tag name (repeatable)") { AllowMultipleArgumentsPerToken = false };
 
@@ -30,37 +34,248 @@ public static class PostCommands
 
         cmd.AddOption(titleOpt);
         cmd.AddOption(contentOpt);
+        cmd.AddOption(fileOpt);
         cmd.AddOption(draftOpt);
         cmd.AddOption(tagsOpt);
 
-        cmd.SetHandler(async (url, key, title, contentFile, draft, tags) =>
+        cmd.SetHandler(async (url, key, title, contentFile, file, draft, tags) =>
         {
-            var content = contentFile is not null
-                ? await File.ReadAllTextAsync(contentFile.FullName)
-                : string.Empty;
+            string content;
+            string[] resolvedTags;
+            string resolvedTitle;
+            PostFrontmatter frontmatter = new();
+
+            if (file is not null)
+            {
+                var raw = await File.ReadAllTextAsync(file.FullName);
+                (frontmatter, var body) = FrontmatterParser.Parse(raw);
+
+                resolvedTitle = title ?? frontmatter.Title;
+                resolvedTags = (tags is { Length: > 0 } ? tags : frontmatter.Tags) ?? Array.Empty<string>();
+                content = body;
+            }
+            else
+            {
+                resolvedTitle = title ?? string.Empty;
+                resolvedTags = tags ?? Array.Empty<string>();
+                content = contentFile is not null
+                    ? await File.ReadAllTextAsync(contentFile.FullName)
+                    : string.Empty;
+            }
+
+            if (string.IsNullOrWhiteSpace(resolvedTitle))
+            {
+                Console.Error.WriteLine("Error: --title is required when --file is not provided.");
+                return;
+            }
 
             var client = new ApiClient(url, key);
             var result = await client.PostAsync("/api/posts", new
             {
-                title,
+                title = resolvedTitle,
                 content,
-                tags = tags ?? Array.Empty<string>()
+                tags = resolvedTags
             });
 
             if (result is null) return;
 
-            var id = result.Value.GetProperty("id").GetString();
+            var id = result.Value.GetProperty("id").GetString()!;
             var slug = result.Value.GetProperty("slug").GetString();
             Console.WriteLine($"Created: {slug} ({id})");
+
+            if (file is not null)
+            {
+                FrontmatterParser.WritePostId(file.FullName, id);
+
+                if (frontmatter.ScheduledAt is null)
+                    FrontmatterParser.WriteScheduledAt(file.FullName, FrontmatterParser.DefaultScheduledAt());
+            }
 
             if (!draft)
             {
                 await client.PostAsync($"/api/posts/{id}/publish");
                 Console.WriteLine("Published.");
+
+                if (file is not null)
+                    MoveToPublished(file.FullName);
             }
-        }, urlOpt, keyOpt, titleOpt, contentOpt, draftOpt, tagsOpt);
+        }, urlOpt, keyOpt, titleOpt, contentOpt, fileOpt, draftOpt, tagsOpt);
 
         return cmd;
+    }
+
+    private static Command BuildNew(Option<string> urlOpt, Option<string> keyOpt)
+    {
+        var cmd = new Command("new", "Create a new draft post and generate its .md file");
+        var titleOpt = new Option<string>("--title", "Post title") { IsRequired = true };
+        var tagsOpt = new Option<string[]>("--tag", "Tag name (repeatable)") { AllowMultipleArgumentsPerToken = false };
+        var dirOpt = new Option<string>("--dir", "Directory to create the file in");
+
+        dirOpt.SetDefaultValue("./docs/posts/drafts");
+
+        cmd.AddOption(titleOpt);
+        cmd.AddOption(tagsOpt);
+        cmd.AddOption(dirOpt);
+
+        cmd.SetHandler(async (url, key, title, tags, dir) =>
+        {
+            var scheduledAt = FrontmatterParser.DefaultScheduledAt();
+            var resolvedTags = tags ?? Array.Empty<string>();
+
+            var client = new ApiClient(url, key);
+            var result = await client.PostAsync("/api/posts", new
+            {
+                title,
+                content = "",
+                tags = resolvedTags
+            });
+
+            if (result is null) return;
+
+            var id = result.Value.GetProperty("id").GetString()!;
+            var slug = result.Value.GetProperty("slug").GetString()!;
+
+            Directory.CreateDirectory(dir);
+            var filePath = Path.Combine(dir, $"{slug}.md");
+            FrontmatterParser.CreateDraftFile(filePath, title, resolvedTags, id, scheduledAt);
+
+            Console.WriteLine($"Created: {filePath}");
+            Console.WriteLine($"Post ID: {id}");
+        }, urlOpt, keyOpt, titleOpt, tagsOpt, dirOpt);
+
+        return cmd;
+    }
+
+    private static void MoveToPublished(string filePath)
+    {
+        var readySegment = Path.DirectorySeparatorChar + "ready" + Path.DirectorySeparatorChar;
+        if (!filePath.Contains(readySegment)) return;
+
+        var publishedPath = filePath.Replace(readySegment, Path.DirectorySeparatorChar + "published" + Path.DirectorySeparatorChar);
+        Directory.CreateDirectory(Path.GetDirectoryName(publishedPath)!);
+        File.Move(filePath, publishedPath, overwrite: false);
+        Console.WriteLine($"Moved to: {publishedPath}");
+    }
+
+    private static Command BuildSchedule(Option<string> urlOpt, Option<string> keyOpt)
+    {
+        var cmd = new Command("schedule", "Schedule a post for future publishing");
+        var idArg = new Argument<string>("id", "Post ID (GUID)");
+        var atOpt = new Option<string>("--at", "Publish datetime (ISO 8601 or 'tomorrow 9am')") { IsRequired = true };
+
+        cmd.AddArgument(idArg);
+        cmd.AddOption(atOpt);
+
+        cmd.SetHandler(async (url, key, id, at) =>
+        {
+            var scheduledAt = ParseDatetime(at);
+            if (scheduledAt is null)
+            {
+                Console.Error.WriteLine($"Error: could not parse datetime '{at}'. Use ISO 8601 (e.g. 2026-03-25T09:00:00Z) or 'tomorrow 9am'.");
+                return;
+            }
+
+            // Fetch slug from admin posts list
+            var client = new ApiClient(url, key);
+            var posts = await client.GetAsync("/api/admin/posts");
+            if (posts is null) return;
+
+            string? slug = null;
+            foreach (var post in posts.Value.EnumerateArray())
+            {
+                if (post.GetProperty("id").GetString() == id)
+                {
+                    slug = post.GetProperty("slug").GetString();
+                    break;
+                }
+            }
+
+            if (slug is null)
+            {
+                Console.Error.WriteLine($"Error: post with id '{id}' not found.");
+                return;
+            }
+
+            var repoRoot = FindRepoRoot(Directory.GetCurrentDirectory());
+            if (repoRoot is null)
+            {
+                Console.Error.WriteLine("Error: could not find git repository root.");
+                return;
+            }
+
+            var workflowDir = Path.Combine(repoRoot, ".github", "workflows");
+            Directory.CreateDirectory(workflowDir);
+
+            var dateLabel = scheduledAt.Value.ToString("yyyy-MM-dd");
+            var workflowFile = Path.Combine(workflowDir, $"publish-{slug}-{dateLabel}.yml");
+
+            var cron = ToCronExpression(scheduledAt.Value);
+            var apiUrl = url.TrimEnd('/');
+
+            var yaml = "name: Publish \u2014 " + slug + "\n" +
+                       "on:\n" +
+                       "  schedule:\n" +
+                       $"    - cron: '{cron}'   # {scheduledAt.Value:u} UTC\n" +
+                       "  workflow_dispatch:\n" +
+                       "jobs:\n" +
+                       "  publish:\n" +
+                       "    runs-on: ubuntu-latest\n" +
+                       "    steps:\n" +
+                       "      - name: Publish post\n" +
+                       "        run: |\n" +
+                       "          curl -sf -X POST \\\n" +
+                       "            -H \"X-Admin-Key: ${{ secrets.TAC_API_KEY }}\" \\\n" +
+                       $"            {apiUrl}/api/posts/{id}/publish\n";
+
+            await File.WriteAllTextAsync(workflowFile, yaml);
+            Console.WriteLine($"Scheduled: {scheduledAt.Value:u}");
+            Console.WriteLine($"Workflow:  {workflowFile}");
+        }, urlOpt, keyOpt, idArg, atOpt);
+
+        return cmd;
+    }
+
+    private static DateTime? ParseDatetime(string input)
+    {
+        // Try ISO 8601 first
+        if (DateTime.TryParse(input, null, System.Globalization.DateTimeStyles.RoundtripKind, out var iso))
+            return iso.ToUniversalTime();
+
+        // Simple natural language: "tomorrow 9am", "tomorrow 14:00"
+        var lower = input.Trim().ToLowerInvariant();
+        var baseDate = lower.StartsWith("tomorrow") ? DateTime.UtcNow.Date.AddDays(1) : (DateTime?)null;
+
+        if (baseDate is null) return null;
+
+        var timeStr = lower.Replace("tomorrow", "").Trim();
+        if (string.IsNullOrEmpty(timeStr)) return baseDate;
+
+        var timeMatch = Regex.Match(timeStr, @"^(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$");
+        if (!timeMatch.Success) return null;
+
+        var hour = int.Parse(timeMatch.Groups[1].Value);
+        var minute = timeMatch.Groups[2].Success ? int.Parse(timeMatch.Groups[2].Value) : 0;
+        var ampm = timeMatch.Groups[3].Value;
+
+        if (ampm == "pm" && hour < 12) hour += 12;
+        if (ampm == "am" && hour == 12) hour = 0;
+
+        return baseDate.Value.AddHours(hour).AddMinutes(minute);
+    }
+
+    private static string ToCronExpression(DateTime utc)
+        => $"{utc.Minute} {utc.Hour} {utc.Day} {utc.Month} *";
+
+    private static string? FindRepoRoot(string startPath)
+    {
+        var dir = new DirectoryInfo(startPath);
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return null;
     }
 
     private static Command BuildList(Option<string> urlOpt, Option<string> keyOpt)

--- a/backend/src/TacBlog.Cli/FrontmatterParser.cs
+++ b/backend/src/TacBlog.Cli/FrontmatterParser.cs
@@ -1,0 +1,92 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace TacBlog.Cli;
+
+public sealed class PostFrontmatter
+{
+    public string Title { get; init; } = "";
+    public string[] Tags { get; init; } = [];
+    public string? PostId { get; init; }
+    public DateTime? ScheduledAt { get; init; }
+}
+
+public static class FrontmatterParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    private static readonly ISerializer Serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static (PostFrontmatter Frontmatter, string Body) Parse(string fileContent)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            fileContent,
+            @"^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$"
+        );
+
+        if (!match.Success)
+            return (new PostFrontmatter(), fileContent);
+
+        var yaml = match.Groups[1].Value;
+        var body = match.Groups[2].Value;
+
+        var frontmatter = Deserializer.Deserialize<PostFrontmatter>(yaml)
+            ?? new PostFrontmatter();
+
+        return (frontmatter, body);
+    }
+
+    public static void WritePostId(string filePath, string postId)
+        => WriteOrUpdateYamlField(filePath, "postId", postId);
+
+    public static void WriteScheduledAt(string filePath, DateTime scheduledAt)
+        => WriteOrUpdateYamlField(filePath, "scheduledAt", scheduledAt.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+
+    public static DateTime DefaultScheduledAt()
+        => DateTime.Now.Date.AddDays(1).AddHours(9);
+
+    public static void CreateDraftFile(string filePath, string title, string[] tags, string postId, DateTime scheduledAt)
+    {
+        var yaml = $"title: {title}\n" +
+                   $"tags: [{string.Join(", ", tags)}]\n" +
+                   $"postId: {postId}\n" +
+                   $"scheduledAt: {scheduledAt:yyyy-MM-ddTHH:mm:ssZ}";
+
+        File.WriteAllText(filePath, $"---\n{yaml}\n---\n\n");
+    }
+
+    private static void WriteOrUpdateYamlField(string filePath, string field, string value)
+    {
+        var raw = File.ReadAllText(filePath);
+        var match = System.Text.RegularExpressions.Regex.Match(
+            raw,
+            @"^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$"
+        );
+
+        if (!match.Success) return;
+
+        var yaml = match.Groups[1].Value;
+        var body = match.Groups[2].Value;
+
+        if (System.Text.RegularExpressions.Regex.IsMatch(yaml, $@"^{field}:.*$", System.Text.RegularExpressions.RegexOptions.Multiline))
+        {
+            yaml = System.Text.RegularExpressions.Regex.Replace(
+                yaml,
+                $@"^{field}:.*$",
+                $"{field}: {value}",
+                System.Text.RegularExpressions.RegexOptions.Multiline
+            );
+        }
+        else
+        {
+            yaml = yaml.TrimEnd() + $"\n{field}: {value}";
+        }
+
+        File.WriteAllText(filePath, $"---\n{yaml}\n---\n{body}");
+    }
+}

--- a/backend/src/TacBlog.Cli/Program.cs
+++ b/backend/src/TacBlog.Cli/Program.cs
@@ -4,7 +4,7 @@ using TacBlog.Cli.Commands;
 
 var urlOpt = new Option<string>(
     "--url",
-    () => Environment.GetEnvironmentVariable("TAC_API_URL") ?? "http://localhost:5205",
+    () => Environment.GetEnvironmentVariable("TAC_API_URL") ?? "http://localhost:5063",
     "API base URL");
 
 var keyOpt = new Option<string>(

--- a/backend/src/TacBlog.Cli/TacBlog.Cli.csproj
+++ b/backend/src/TacBlog.Cli/TacBlog.Cli.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
 </Project>

--- a/frontend/editor-server.ts
+++ b/frontend/editor-server.ts
@@ -1,0 +1,185 @@
+// editor-server.ts — Standalone tac-editor HTTP server (no Astro dev server required)
+// Binds to 127.0.0.1:3456 (loopback only — not reachable from the network)
+
+import * as http from 'node:http';
+import { readFile, writeFile } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
+import { renderMarkdown, slugifyHeading } from './src/data/markdown';
+import { buildHtml } from './editor-template';
+
+const PORT = 3456;
+const HOST = '127.0.0.1';
+
+// ── Frontmatter helpers ─────────────────────────────
+
+interface Frontmatter {
+  body: string;
+  title: string;
+  tags: string[];
+  postId: string | null;
+  scheduledAt: string | null;
+}
+
+function parseFrontmatter(raw: string): Frontmatter {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { body: raw, title: 'Untitled', tags: [], postId: null, scheduledAt: null };
+
+  const yaml = match[1];
+  const body = match[2];
+
+  const titleMatch       = yaml.match(/^title:\s*["']?(.+?)["']?\s*$/m);
+  const tagsMatch        = yaml.match(/^tags:\s*\[([^\]]*)\]/m);
+  const postIdMatch      = yaml.match(/^postId:\s*(.+?)\s*$/m);
+  const scheduledAtMatch = yaml.match(/^scheduledAt:\s*(.+?)\s*$/m);
+
+  const title       = titleMatch?.[1] ?? 'Untitled Preview';
+  const tags        = tagsMatch?.[1]
+    ? tagsMatch[1].split(',').map(t => t.trim().replace(/^["']|["']$/g, '')).filter(Boolean)
+    : [];
+  const postId      = postIdMatch?.[1] ?? null;
+  const scheduledAt = scheduledAtMatch?.[1] ?? null;
+
+  return { body, title, tags, postId, scheduledAt };
+}
+
+// ── Security validation ─────────────────────────────
+
+function isValidPath(filePath: unknown): filePath is string {
+  if (typeof filePath !== 'string') return false;
+  if (!isAbsolute(filePath)) return false;
+  if (filePath.includes('..')) return false;
+  if (!filePath.endsWith('.md')) return false;
+  return true;
+}
+
+// ── Request body reader ─────────────────────────────
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', reject);
+  });
+}
+
+// ── Route handlers ──────────────────────────────────
+
+async function handleEdit(req: http.IncomingMessage, res: http.ServerResponse, url: URL): Promise<void> {
+  const filePath = url.searchParams.get('file');
+  if (!isValidPath(filePath)) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('Invalid file path');
+    return;
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf-8');
+  } catch {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('File not found');
+    return;
+  }
+
+  const { body, title, tags, postId, scheduledAt } = parseFrontmatter(raw);
+  const renderedHtml = await renderMarkdown(body);
+  const editMode = url.searchParams.has('edit');
+
+  const headings = body.split('\n')
+    .filter(line => line.startsWith('## ') || line.startsWith('### '))
+    .map(line => {
+      const text = line.replace(/^#+\s+/, '');
+      return { text, id: slugifyHeading(text) };
+    });
+
+  const words = body.split(/\s+/).filter(Boolean).length;
+  const readingTime = `${Math.max(1, Math.ceil(words / 200))} min read`;
+
+  const html = buildHtml({ filePath, title, tags, postId, scheduledAt, initialContent: raw, renderedHtml, headings, readingTime, editMode });
+  res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(html);
+}
+
+async function handleRender(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const bodyText = await readBody(req);
+  let content: string;
+  try {
+    content = JSON.parse(bodyText)?.content ?? '';
+  } catch {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('Invalid JSON');
+    return;
+  }
+
+  const { body } = parseFrontmatter(content);
+  const html = await renderMarkdown(body);
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ html }));
+}
+
+async function handleFilePut(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const bodyText = await readBody(req);
+  let parsed: { filePath?: unknown; content?: unknown };
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('Invalid JSON');
+    return;
+  }
+
+  if (!isValidPath(parsed.filePath)) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('Invalid file path');
+    return;
+  }
+
+  const content = typeof parsed.content === 'string' ? parsed.content : '';
+  await writeFile(parsed.filePath, content, 'utf-8');
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('ok');
+}
+
+// ── Server ──────────────────────────────────────────
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? '/', `http://${HOST}:${PORT}`);
+
+  try {
+    if (req.method === 'GET' && url.pathname === '/health') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/edit') {
+      await handleEdit(req, res, url);
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/render') {
+      await handleRender(req, res);
+      return;
+    }
+
+    if (req.method === 'PUT' && url.pathname === '/file') {
+      await handleFilePut(req, res);
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  } catch (err) {
+    console.error('[tac-editor] Unhandled error:', err);
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('Internal server error');
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`tac-editor @ http://${HOST}:${PORT}`);
+  // Eager warm-up: trigger Shiki highlighter initialisation so the first /edit
+  // request returns immediately instead of waiting for language bundle loading.
+  renderMarkdown('```ts\nconst x = 1;\n```').catch(() => {});
+});

--- a/frontend/editor-template.ts
+++ b/frontend/editor-template.ts
@@ -1,0 +1,1360 @@
+// editor-template.ts — Standalone editor HTML template (Forge & Ink design, no Astro/Tailwind)
+
+export interface BuildHtmlOptions {
+  filePath: string;
+  title: string;
+  tags: string[];
+  postId: string | null;
+  scheduledAt: string | null;
+  initialContent: string;    // raw (with frontmatter) → textarea
+  renderedHtml: string;      // rendered HTML of the body
+  headings: Array<{text: string, id: string}>;
+  readingTime: string;
+  editMode: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ── Tag badge helper ──────────────────────────────────
+
+function buildTagBadge(tag: string): string {
+  const slug = tag.toLowerCase().replace(/\s+/g, '-');
+  return `<span class="tag-badge-md tag--${escapeHtml(slug)}">${escapeHtml(tag)}</span>`;
+}
+
+// ── TOC helper ────────────────────────────────────────
+
+function buildTocHtml(headings: Array<{text: string, id: string}>): string {
+  if (headings.length <= 1) return '';
+  const links = headings
+    .map(h => `<a href="#${escapeHtml(h.id)}" class="toc-link">${escapeHtml(h.text)}</a>`)
+    .join('\n              ');
+  return `<aside class="toc-sidebar">
+            <nav class="toc-nav" aria-label="Table of contents">
+              <p class="toc-label">On this page</p>
+              ${links}
+            </nav>
+          </aside>`;
+}
+
+// ── Site header HTML ──────────────────────────────────
+
+function buildNavHtml(): string {
+  return `<header class="site-header">
+    <nav class="site-nav">
+      <a href="/" class="logo-link" aria-label="Home">
+        <div class="craft-mark">
+          <div class="craft-mark-outer"></div>
+          <div class="craft-mark-inner"></div>
+        </div>
+        <span class="logo-text">The Augmented Craftsman</span>
+      </a>
+      <div class="nav-links">
+        <a href="/" class="nav-link">Home</a>
+        <a href="/blog" class="nav-link nav-link--active">Writing</a>
+        <a href="/tags" class="nav-link">Topics</a>
+        <a href="/about" class="nav-link">About</a>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
+          <svg class="theme-icon-sun" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <circle cx="12" cy="12" r="5"/>
+            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+          </svg>
+          <svg class="theme-icon-moon" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </header>`;
+}
+
+// ── Site footer HTML ──────────────────────────────────
+
+function buildFooterHtml(year: number): string {
+  return `<footer class="site-footer">
+    <div class="site-footer-inner">
+      <div class="site-footer-grid">
+        <div class="footer-brand">
+          <div class="footer-logo">
+            <div class="footer-craft-mark">
+              <div class="footer-craft-mark-outer"></div>
+              <div class="footer-craft-mark-inner"></div>
+            </div>
+            <span class="footer-logo-text">The Augmented Craftsman</span>
+          </div>
+          <p class="footer-tagline">Crafting software with intention.<br/>TDD. Clean Architecture. Deliberate practice.</p>
+        </div>
+        <div class="footer-links">
+          <div class="footer-links-col">
+            <p class="footer-links-heading">Navigate</p>
+            <a href="/blog" class="footer-link">Writing</a>
+            <a href="/tags" class="footer-link">Topics</a>
+            <a href="/about" class="footer-link">About</a>
+          </div>
+          <div class="footer-links-col">
+            <p class="footer-links-heading">Connect</p>
+            <a href="https://github.com/christianBorrello" target="_blank" rel="noopener" class="footer-link footer-link-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/></svg>
+              GitHub
+            </a>
+            <a href="https://www.linkedin.com/in/christianborrello99/" target="_blank" rel="noopener" class="footer-link footer-link-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286ZM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065Zm1.782 13.019H3.555V9h3.564v11.452ZM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003Z"/></svg>
+              LinkedIn
+            </a>
+            <a href="https://christianborrello.dev/en" target="_blank" rel="noopener" class="footer-link footer-link-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
+              Who I Am
+            </a>
+            <a href="/rss.xml" class="footer-link footer-link-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>
+              RSS Feed
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; ${year} Christian Borrello. Built with craft.</p>
+        <p class="footer-bottom-right">Made with <span class="footer-craft-icon"><span class="footer-craft-icon-inner"></span></span> and Astro</p>
+      </div>
+    </div>
+  </footer>`;
+}
+
+// ── CSS (self-contained, class-based dark mode) ───────
+
+const CSS = `
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=JetBrains+Mono:wght@400;500;600&family=Literata:ital,opsz,wght@0,7..72,300..800;1,7..72,300..800&display=swap');
+
+/* ── Design Tokens (light) ─────────────────────────── */
+:root {
+  --color-bg: #FDFAF6;
+  --color-bg-surface: #F5F0E8;
+  --color-text: #1C1917;
+  --color-text-muted: #6B5F4F;
+  --color-accent: #B45309;
+  --color-accent-hover: #D97706;
+  --color-border: #D4C8B8;
+  --grain-opacity: 0.03;
+  --color-bg-alpha80: rgba(253,250,246,0.8);
+}
+
+/* ── Design Tokens (dark) — class-based ────────────── */
+.dark {
+  --color-bg: #0F0E0C;
+  --color-bg-surface: #1A1816;
+  --color-text: #E7E0D6;
+  --color-text-muted: #B0A08A;
+  --color-accent: #E5A84B;
+  --color-accent-hover: #F0C060;
+  --color-border: #2E2A25;
+  --grain-opacity: 0.04;
+  --color-bg-alpha80: rgba(15,14,12,0.8);
+}
+
+/* ── Base ──────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: 'Literata', Georgia, serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  margin: 0;
+  padding-top: 36px;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+::selection { background-color: var(--color-accent); color: white; }
+
+/* ── Editor Strip (fixed, always visible) ──────────── */
+.editor-strip {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: 36px;
+  z-index: 200;
+  background: var(--color-accent);
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0 1rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6875rem;
+}
+
+.strip-draft {
+  font-weight: 700;
+  color: white;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.strip-filepath {
+  color: rgba(255,255,255,0.8);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  max-width: 50vw;
+}
+
+.strip-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.strip-btn {
+  padding: 0.2rem 0.6rem;
+  background: rgba(255,255,255,0.15);
+  color: white;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 500;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+}
+
+.strip-btn:hover { background: rgba(255,255,255,0.25); }
+.strip-btn--active { background: rgba(255,255,255,0.3); font-weight: 700; }
+
+.strip-save-status { color: white; min-width: 4ch; }
+.strip-cmd-hint { color: rgba(255,255,255,0.7); }
+
+/* ── Site Header (sticky below strip) ─────────────── */
+.site-header {
+  position: sticky;
+  top: 36px;
+  z-index: 50;
+  background: var(--color-bg-alpha80);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-nav {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+@media (min-width: 768px) { .site-nav { padding: 0 2.5rem; } }
+
+.logo-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+}
+
+.craft-mark { width: 32px; height: 32px; position: relative; flex-shrink: 0; }
+.craft-mark-outer { position: absolute; inset: 0; border: 2px solid var(--color-accent); border-radius: 2px; }
+.craft-mark-inner { position: absolute; inset: 4px; border: 2px solid var(--color-text); border-radius: 2px; opacity: 0.4; }
+
+.logo-text {
+  font-family: 'Fraunces', Georgia, serif;
+  font-weight: 600;
+  font-size: 1.125rem;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+
+.nav-links { display: flex; align-items: center; gap: 0.25rem; }
+@media (min-width: 768px) { .nav-links { gap: 0.5rem; } }
+
+.nav-link {
+  padding: 0.375rem 0.75rem;
+  border-radius: 8px;
+  font-family: 'Literata', Georgia, serif;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover { color: var(--color-text); background: var(--color-bg-surface); }
+.nav-link--active { color: var(--color-accent); background: var(--color-bg-surface); }
+
+.theme-toggle {
+  margin-left: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  transition: all 0.2s ease;
+}
+
+.theme-toggle:hover { color: var(--color-text); background: var(--color-bg-surface); }
+
+.theme-icon-sun  { display: none; }
+.dark .theme-icon-sun  { display: block; }
+.theme-icon-moon { display: block; }
+.dark .theme-icon-moon { display: none; }
+
+/* ── Post Article ──────────────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: none; }
+}
+
+.post-article {
+  padding: 3rem 1.5rem 0;
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .post-article { padding-top: 5rem; padding-left: 2.5rem; padding-right: 2.5rem; }
+}
+
+.post-inner { max-width: 56rem; margin: 0 auto; }
+
+.post-header {
+  margin-bottom: 3rem;
+  animation: fadeUp 0.6s ease both;
+}
+
+@media (min-width: 768px) { .post-header { margin-bottom: 4rem; } }
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 2rem;
+  transition: color 0.2s ease;
+}
+
+.back-link:hover { color: var(--color-accent); }
+
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+  margin-bottom: 1rem;
+}
+
+.post-meta-dot {
+  width: 4px; height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.post-title-display {
+  font-family: 'Fraunces', Georgia, serif;
+  font-weight: 600;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1.1;
+  letter-spacing: -0.025em;
+  color: var(--color-text);
+  margin: 0;
+}
+
+@media (min-width: 768px) {
+  .post-title-display {
+    font-size: clamp(3rem, 6vw, 5.5rem);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+  }
+}
+
+/* ── Tag Badges ────────────────────────────────────── */
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 1.5rem; }
+
+.tag-badge-md {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+  padding: 0.375rem 0.75rem;
+  background: var(--color-bg-surface);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.tag--tdd               { background:rgba(217,119,6,.1);   color:#D97706; border-color:rgba(217,119,6,.2); }
+.dark .tag--tdd         { background:rgba(251,191,36,.1);  color:#FBBF24; border-color:rgba(251,191,36,.2); }
+.tag--clean-architecture               { background:rgba(5,150,105,.1);   color:#059669; border-color:rgba(5,150,105,.2); }
+.dark .tag--clean-architecture         { background:rgba(52,211,153,.1);  color:#34D399; border-color:rgba(52,211,153,.2); }
+.tag--ddd               { background:rgba(124,58,237,.1);  color:#7C3AED; border-color:rgba(124,58,237,.2); }
+.dark .tag--ddd         { background:rgba(167,139,250,.1); color:#A78BFA; border-color:rgba(167,139,250,.2); }
+.tag--solid             { background:rgba(2,132,199,.1);   color:#0284C7; border-color:rgba(2,132,199,.2); }
+.dark .tag--solid       { background:rgba(56,189,248,.1);  color:#38BDF8; border-color:rgba(56,189,248,.2); }
+.tag--refactoring       { background:rgba(225,29,72,.1);   color:#E11D48; border-color:rgba(225,29,72,.2); }
+.dark .tag--refactoring { background:rgba(251,113,133,.1); color:#FB7185; border-color:rgba(251,113,133,.2); }
+.tag--csharp            { background:rgba(79,70,229,.1);   color:#4F46E5; border-color:rgba(79,70,229,.2); }
+.dark .tag--csharp      { background:rgba(129,140,248,.1); color:#818CF8; border-color:rgba(129,140,248,.2); }
+.tag--testing           { background:rgba(13,148,136,.1);  color:#0D9488; border-color:rgba(13,148,136,.2); }
+.dark .tag--testing     { background:rgba(45,212,204,.1);  color:#2DD4BF; border-color:rgba(45,212,204,.2); }
+.tag--xp                { background:rgba(234,88,12,.1);   color:#EA580C; border-color:rgba(234,88,12,.2); }
+.dark .tag--xp          { background:rgba(251,146,60,.1);  color:#FB923C; border-color:rgba(251,146,60,.2); }
+
+/* ── Two-column layout ─────────────────────────────── */
+.post-content { display: flex; gap: 3rem; }
+@media (min-width: 1024px) { .post-content { gap: 4rem; } }
+
+.prose-wrapper {
+  flex: 1;
+  min-width: 0;
+  animation: fadeUp 0.6s ease both;
+  animation-delay: 150ms;
+}
+
+/* ── TOC Sidebar ───────────────────────────────────── */
+.toc-sidebar { display: none; width: 14rem; flex-shrink: 0; }
+@media (min-width: 1024px) { .toc-sidebar { display: block; } }
+
+.toc-nav {
+  position: sticky;
+  top: 124px; /* 36px strip + 64px header + 24px padding */
+}
+
+.toc-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin: 0 0 0.75rem;
+}
+
+.toc-link {
+  display: block;
+  font-family: 'Literata', Georgia, serif;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  padding: 0.25rem 0.75rem;
+  border-left: 2px solid var(--color-border);
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.toc-link:hover { color: var(--color-accent); border-left-color: var(--color-accent); }
+
+/* ── Post Footer ───────────────────────────────────── */
+.post-footer {
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.post-footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.post-author-title {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.post-author-title strong { color: var(--color-text); }
+
+.post-author-role {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin: 0.25rem 0 0;
+}
+
+.more-posts-link {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9375rem;
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.more-posts-link:hover { text-decoration: underline; }
+
+/* ── Comments Placeholder ──────────────────────────── */
+.comments-section { margin-top: 3rem; padding-bottom: 2rem; }
+
+.comments-heading {
+  font-family: 'Fraunces', Georgia, serif;
+  font-weight: 600;
+  font-size: 1.5rem;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  margin: 0 0 1.5rem;
+}
+
+.comment-signin {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.comments-subtitle {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 0.5rem;
+}
+
+.comments-note {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+  margin: 0 0 1.5rem;
+}
+
+.oauth-buttons { display: flex; justify-content: center; gap: 0.75rem; flex-wrap: wrap; }
+
+.oauth-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: not-allowed;
+  opacity: 0.5;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+/* ── Site Footer ───────────────────────────────────── */
+.site-footer { border-top: 1px solid var(--color-border); margin-top: 6rem; }
+
+.site-footer-inner { max-width: 80rem; margin: 0 auto; padding: 3rem 1.5rem; }
+@media (min-width: 768px) { .site-footer-inner { padding: 4rem 2.5rem; } }
+
+.site-footer-grid { display: flex; flex-direction: column; align-items: flex-start; gap: 2rem; }
+@media (min-width: 768px) {
+  .site-footer-grid { flex-direction: row; align-items: center; justify-content: space-between; }
+}
+
+.footer-brand { display: flex; flex-direction: column; gap: 0.75rem; }
+.footer-logo { display: flex; align-items: center; gap: 0.75rem; }
+
+.footer-craft-mark { width: 24px; height: 24px; position: relative; flex-shrink: 0; }
+.footer-craft-mark-outer { position: absolute; inset: 0; border: 2px solid var(--color-accent); border-radius: 2px; }
+.footer-craft-mark-inner { position: absolute; inset: 2px; border: 1px solid var(--color-text); border-radius: 2px; opacity: 0.3; }
+
+.footer-logo-text {
+  font-family: 'Fraunces', Georgia, serif;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+
+.footer-tagline {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--color-text-muted);
+  max-width: 20rem;
+  margin: 0;
+}
+
+.footer-links { display: flex; gap: 3rem; font-size: 0.9375rem; }
+.footer-links-col { display: flex; flex-direction: column; gap: 0.5rem; }
+
+.footer-links-heading {
+  font-family: 'Fraunces', Georgia, serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin: 0 0 0.25rem;
+}
+
+.footer-link { color: var(--color-text-muted); text-decoration: none; transition: color 0.2s ease; }
+.footer-link:hover { color: var(--color-accent); }
+.footer-link-icon { display: flex; align-items: center; gap: 0.5rem; }
+
+.footer-bottom {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+@media (min-width: 640px) { .footer-bottom { flex-direction: row; } }
+.footer-bottom p { margin: 0; }
+.footer-bottom-right { display: flex; align-items: center; gap: 0.375rem; }
+.footer-craft-icon { display: inline-block; width: 12px; height: 12px; position: relative; }
+.footer-craft-icon-inner { position: absolute; inset: 0; border: 1px solid var(--color-accent); border-radius: 2px; transform: rotate(45deg); }
+
+/* ── Edit Container ────────────────────────────────── */
+.edit-container { min-height: calc(100vh - 36px); display: flex; flex-direction: column; }
+
+.editor-textarea {
+  flex: 1;
+  width: 100%;
+  padding: 1.5rem 2rem;
+  background: var(--color-bg-surface);
+  color: var(--color-text);
+  border: none;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  line-height: 1.7;
+  resize: none;
+  outline: none;
+  box-sizing: border-box;
+  caret-color: var(--color-accent);
+  tab-size: 2;
+}
+.editor-textarea:focus {
+  box-shadow: inset 3px 0 0 var(--color-accent);
+}
+
+/* ── Markdown Toolbar ──────────────────────────────── */
+.md-toolbar {
+  flex-shrink: 0;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  user-select: none;
+  gap: 0;
+}
+.md-toolbar::-webkit-scrollbar { display: none; }
+.md-toolbar-group { display: flex; align-items: center; gap: 1px; }
+.md-toolbar-sep { width: 1px; height: 16px; background: var(--color-border); margin: 0 0.5rem; flex-shrink: 0; }
+
+.md-btn {
+  padding: 0.25rem 0.5rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  white-space: nowrap;
+}
+.md-btn:hover { background: var(--color-bg); color: var(--color-accent); border-color: var(--color-border); }
+.md-btn:active { background: var(--color-accent); color: white; border-color: var(--color-accent); }
+
+/* ── Editor Statusbar ──────────────────────────────── */
+.editor-statusbar {
+  flex-shrink: 0;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1rem;
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+}
+.status-sep { opacity: 0.4; }
+.status-right { margin-left: auto; opacity: 0.5; font-size: 0.625rem; }
+
+/* ── Editor Meta Row ───────────────────────────────── */
+.editor-meta-row {
+  flex-shrink: 0;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.75rem;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+.meta-label { opacity: 0.65; flex-shrink: 0; }
+.meta-sep   { opacity: 0.35; flex-shrink: 0; }
+.meta-postid {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
+  transition: color 0.15s ease;
+}
+.meta-postid:hover { color: var(--color-accent); }
+.meta-datetime {
+  height: 22px;
+  padding: 0 0.4rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  outline: none;
+  cursor: pointer;
+}
+.meta-datetime:focus { border-color: var(--color-accent); }
+.dark .meta-datetime { color-scheme: dark; }
+
+/* ── Prose Forge ───────────────────────────────────── */
+.prose-forge {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 1.0625rem;
+  line-height: 1.8;
+  color: var(--color-text);
+  max-width: 68ch;
+}
+
+.prose-forge h2 {
+  font-family: 'Fraunces', Georgia, serif;
+  font-weight: 600;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  letter-spacing: -0.02em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  color: var(--color-text);
+}
+
+.prose-forge h3 {
+  font-family: 'Fraunces', Georgia, serif;
+  font-weight: 500;
+  font-size: 1.35rem;
+  letter-spacing: -0.015em;
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.prose-forge p { margin-bottom: 1.5rem; }
+
+.prose-forge a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-decoration-color: var(--color-accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.2s ease;
+}
+
+.prose-forge a:hover { text-decoration-thickness: 2px; }
+
+.prose-forge blockquote {
+  border-left: 3px solid var(--color-accent);
+  padding-left: 1.5rem;
+  margin: 2rem 0;
+  font-style: italic;
+  color: var(--color-text-muted);
+  font-size: 1.125rem;
+}
+
+.prose-forge ul, .prose-forge ol { margin-bottom: 1.5rem; padding-left: 1.5rem; }
+.prose-forge li { margin-bottom: 0.5rem; }
+.prose-forge li::marker { color: var(--color-accent); }
+.prose-forge strong { font-weight: 700; color: var(--color-text); }
+.prose-forge em { font-style: italic; }
+
+.prose-forge hr { border: none; height: 1px; background: var(--color-border); margin: 3rem 0; }
+
+.prose-forge code:not(pre code) {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875em;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-accent);
+}
+
+.prose-forge img { border-radius: 12px; margin: 2rem 0; border: 1px solid var(--color-border); max-width: 100%; }
+
+/* ── Shiki Dual Theme (class-based) ────────────────── */
+.shiki, .shiki span {
+  color: var(--shiki-light) !important;
+  font-style: var(--shiki-light-font-style) !important;
+}
+
+.dark .shiki, .dark .shiki span {
+  color: var(--shiki-dark) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+}
+
+/* ── Code Blocks ───────────────────────────────────── */
+.code-block {
+  margin: 1.75rem 0;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--code-block-bg);
+  overflow: hidden;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.7;
+  --code-block-bg: #F5F0E8;
+  --code-block-chrome-bg: #EDE7DB;
+  --code-block-gutter-text: #B0A08A;
+  --code-block-gutter-border: #D4C8B8;
+  --code-block-code-text: #3C3836;
+  --code-block-badge-bg: #D4C8B8;
+  --code-block-badge-text: #6B5F4F;
+  --code-block-copy-text: #8A7E72;
+  --code-block-filename-text: #6B5F4F;
+}
+
+.dark .code-block {
+  --code-block-bg: #141210;
+  --code-block-chrome-bg: #141210;
+  --code-block-gutter-text: #4A4139;
+  --code-block-gutter-border: #2E2A25;
+  --code-block-code-text: #A9B7C6;
+  --code-block-badge-bg: #2E2A25;
+  --code-block-badge-text: #B0A08A;
+  --code-block-copy-text: #6B5F4F;
+  --code-block-filename-text: #B0A08A;
+}
+
+.code-block__chrome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 1rem;
+  background: var(--code-block-chrome-bg);
+  border-bottom: 1px solid var(--color-border);
+  user-select: none;
+}
+
+.code-block__dots { display: flex; gap: 6px; }
+.code-block__dot { width: 10px; height: 10px; border-radius: 50%; }
+.code-block__dot--close    { background: #FF5F57; }
+.code-block__dot--minimize { background: #FEBC2E; }
+.code-block__dot--maximize { background: #28C840; }
+
+.code-block__filename { font-size: 0.6875rem; color: var(--code-block-filename-text); letter-spacing: 0.02em; }
+.code-block__actions { display: flex; align-items: center; gap: 0.75rem; }
+
+.code-block__badge {
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  background: var(--code-block-badge-bg);
+  color: var(--code-block-badge-text);
+}
+
+.code-block__copy {
+  background: transparent;
+  border: none;
+  color: var(--code-block-copy-text);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.code-block__copy:hover { color: var(--color-accent); background: var(--code-block-badge-bg); }
+.code-block__copy svg { width: 14px; height: 14px; }
+.code-block__copy--copied { color: #6A8759 !important; }
+.code-block__body { display: flex; overflow-x: auto; }
+
+.code-block__gutter {
+  flex-shrink: 0;
+  padding: 1rem 0;
+  text-align: right;
+  color: var(--code-block-gutter-text);
+  background: var(--code-block-bg);
+  border-right: 1px solid var(--code-block-gutter-border);
+  user-select: none;
+  -webkit-user-select: none;
+  min-width: 3rem;
+}
+
+.code-block__gutter span { display: block; padding: 0 0.75rem; font-size: 0.75rem; line-height: 1.7; }
+.code-block__code { flex: 1; padding: 1rem 1.25rem; overflow-x: auto; color: var(--code-block-code-text); }
+
+.code-block__code pre {
+  margin: 0 !important; padding: 0 !important;
+  background: transparent !important; border: none !important; border-radius: 0 !important;
+  font-family: inherit; font-size: inherit; line-height: inherit;
+}
+
+.code-block__code pre code {
+  font-family: inherit; font-size: inherit; line-height: inherit;
+  background: transparent !important; padding: 0 !important; border: none !important; color: inherit;
+}
+
+.code-block--minimal .code-block__chrome   { padding: 0.5rem 1rem; }
+.code-block--minimal .code-block__dots     { display: none; }
+.code-block--minimal .code-block__filename { display: none; }
+`;
+
+// ── Vanilla JS ────────────────────────────────────────
+
+function buildScript(filePath: string, initialMode: string, postId: string | null, scheduledAt: string | null): string {
+  return `(function () {
+  var FILE_PATH = ${JSON.stringify(filePath)};
+  var DEBOUNCE_MS = 1500;
+  var mode = ${JSON.stringify(initialMode)};
+  var debounceTimer = null;
+
+  var modeToggle   = document.getElementById('mode-toggle');
+  var refreshBtn   = document.getElementById('refresh-btn');
+  var saveStatus   = document.getElementById('save-status');
+  var cmdHint      = document.getElementById('cmd-hint');
+  var pageChrome   = document.getElementById('page-chrome');
+  var editContainer= document.getElementById('edit-container');
+  var proseContent = document.getElementById('prose-content');
+  var editArea     = document.getElementById('edit-area');
+
+  // ── Theme toggle ───────────────────────────────────
+  var themeToggle = document.getElementById('theme-toggle');
+  if (themeToggle) {
+    themeToggle.addEventListener('click', function () {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+  }
+
+  // ── Mode switching ─────────────────────────────────
+  function setMode(newMode) {
+    mode = newMode;
+    if (newMode === 'edit') {
+      pageChrome.style.display    = 'none';
+      editContainer.style.display = 'flex';
+      modeToggle.textContent      = '\\u2190 Preview';
+      modeToggle.classList.add('strip-btn--active');
+      refreshBtn.style.display    = '';
+      cmdHint.style.display       = '';
+    } else {
+      pageChrome.style.display    = 'block';
+      editContainer.style.display = 'none';
+      modeToggle.textContent      = 'Edit';
+      modeToggle.classList.remove('strip-btn--active');
+      refreshBtn.style.display    = 'none';
+      cmdHint.style.display       = 'none';
+      saveStatus.textContent      = '';
+    }
+  }
+
+  modeToggle.addEventListener('click', function () {
+    setMode(mode === 'edit' ? 'preview' : 'edit');
+  });
+
+  // ── Auto-save ──────────────────────────────────────
+  function doSave() {
+    saveStatus.textContent = 'Saving\\u2026';
+    saveStatus.style.color = 'rgba(255,255,255,0.7)';
+    fetch('/file', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filePath: FILE_PATH, content: editArea.value }),
+    }).then(function (res) {
+      if (res.ok) {
+        saveStatus.textContent = 'Saved \\u2713';
+        saveStatus.style.color = 'white';
+      } else {
+        saveStatus.textContent = 'Error \\u2717';
+        saveStatus.style.color = 'white';
+      }
+    }).catch(function () {
+      saveStatus.textContent = 'Error \\u2717';
+      saveStatus.style.color = 'white';
+    });
+  }
+
+  editArea.addEventListener('input', function () {
+    saveStatus.textContent = '';
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(doSave, DEBOUNCE_MS);
+  });
+
+  // ── Copy buttons ───────────────────────────────────
+  function wireCopyButtons() {
+    document.querySelectorAll('.code-block__copy').forEach(function (btn) {
+      var fresh = btn.cloneNode(true);
+      btn.parentNode.replaceChild(fresh, btn);
+      fresh.addEventListener('click', function () {
+        var block  = fresh.closest('.code-block');
+        var codeEl = block && block.querySelector('.code-block__code');
+        var text   = codeEl ? (codeEl.textContent || '') : '';
+        navigator.clipboard.writeText(text).then(function () {
+          fresh.classList.add('code-block__copy--copied');
+          setTimeout(function () { fresh.classList.remove('code-block__copy--copied'); }, 1500);
+        }).catch(function () {});
+      });
+    });
+  }
+
+  // ── Preview refresh ────────────────────────────────
+  function applyRenderedHtml(html) {
+    var parser = new DOMParser();
+    var doc    = parser.parseFromString(html, 'text/html');
+    var nodes  = Array.from(doc.body.childNodes);
+    proseContent.replaceChildren.apply(proseContent, nodes);
+  }
+
+  function doRefreshPreview() {
+    fetch('/render', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: editArea.value }),
+    }).then(function (res) {
+      return res.ok ? res.json() : null;
+    }).then(function (data) {
+      if (!data) return;
+      applyRenderedHtml(data.html);
+      wireCopyButtons();
+      setMode('preview');
+    }).catch(function () {});
+  }
+
+  refreshBtn.addEventListener('click', doRefreshPreview);
+
+  // ── Markdown toolbar helpers ────────────────────────
+  function wrapOrInsert(before, after, placeholder) {
+    var start = editArea.selectionStart;
+    var end   = editArea.selectionEnd;
+    var sel   = editArea.value.substring(start, end) || placeholder;
+    editArea.focus();
+    document.execCommand('insertText', false, before + sel + after);
+    var newStart = start + before.length;
+    editArea.setSelectionRange(newStart, newStart + sel.length);
+    editArea.dispatchEvent(new Event('input'));
+  }
+
+  var TOOLBAR_ACTIONS = {
+    h1:        function() { wrapOrInsert('\\n# ',   '',    'Heading 1'); },
+    h2:        function() { wrapOrInsert('\\n## ',  '',    'Heading 2'); },
+    h3:        function() { wrapOrInsert('\\n### ', '',    'Heading 3'); },
+    bold:      function() { wrapOrInsert('**',  '**',    'bold text'); },
+    italic:    function() { wrapOrInsert('*',   '*',     'italic text'); },
+    code:      function() { wrapOrInsert('\`',   '\`',     'code'); },
+    codeblock: function() { wrapOrInsert('\\n\`\`\`\\n', '\\n\`\`\`\\n', 'language'); },
+    link:      function() {
+      var url = prompt('URL:', 'https://');
+      if (url) wrapOrInsert('[', '](' + url + ')', 'link text');
+    },
+    quote:     function() { wrapOrInsert('\\n> ', '', 'quoted text'); },
+    hr:        function() { wrapOrInsert('\\n\\n---\\n\\n', '', ''); },
+  };
+
+  document.getElementById('md-toolbar').addEventListener('click', function(e) {
+    var btn = e.target.closest('.md-btn');
+    if (!btn) return;
+    var action = btn.dataset.action;
+    if (TOOLBAR_ACTIONS[action]) TOOLBAR_ACTIONS[action]();
+  });
+
+  // ── Tab → 2 spaces ─────────────────────────────────
+  editArea.addEventListener('keydown', function(e) {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      document.execCommand('insertText', false, '  ');
+    }
+  });
+
+  // ── Status bar ──────────────────────────────────────
+  function updateStatus() {
+    var text  = editArea.value;
+    var words = text.trim() === '' ? 0 : text.trim().split(/\\s+/).length;
+    var mins  = Math.max(1, Math.round(words / 200));
+    var beforeCursor = text.substring(0, editArea.selectionStart);
+    var line  = beforeCursor.split('\\n').length;
+    var col   = editArea.selectionStart - beforeCursor.lastIndexOf('\\n');
+    document.getElementById('status-words').textContent     = words + ' words';
+    document.getElementById('status-read-time').textContent = '~' + mins + ' min read';
+    document.getElementById('status-cursor').textContent    = line + ':' + col;
+  }
+  editArea.addEventListener('input', updateStatus);
+  editArea.addEventListener('click', updateStatus);
+  editArea.addEventListener('keyup', updateStatus);
+  updateStatus();
+
+  // ── Keyboard shortcuts ──────────────────────────────
+  document.addEventListener('keydown', function(e) {
+    if (mode !== 'edit') return;
+    var mod = e.metaKey || e.ctrlKey;
+    if (!mod) return;
+    switch (e.key) {
+      case 's': e.preventDefault(); doRefreshPreview(); break;
+      case 'b': e.preventDefault(); TOOLBAR_ACTIONS.bold();   break;
+      case 'i': e.preventDefault(); TOOLBAR_ACTIONS.italic(); break;
+      case 'e': e.preventDefault(); TOOLBAR_ACTIONS.code();   break;
+      case 'k': e.preventDefault(); TOOLBAR_ACTIONS.link();   break;
+      case '1': e.preventDefault(); TOOLBAR_ACTIONS.h1();     break;
+      case '2': e.preventDefault(); TOOLBAR_ACTIONS.h2();     break;
+      case '3': e.preventDefault(); TOOLBAR_ACTIONS.h3();     break;
+    }
+  });
+
+  // ── Meta row: scheduledAt picker ───────────────────
+  var SCHEDULED_AT = ${JSON.stringify(scheduledAt)};
+  var scheduledInput = document.getElementById('scheduled-input');
+
+  if (scheduledInput) {
+    function defaultScheduledLocal() {
+      var d = new Date();
+      d.setDate(d.getDate() + 1);
+      d.setHours(9, 0, 0, 0);
+      var p = function(n) { return n.toString().padStart(2, '0'); };
+      return d.getFullYear()+'-'+p(d.getMonth()+1)+'-'+p(d.getDate())+'T09:00';
+    }
+
+    scheduledInput.value = SCHEDULED_AT
+      ? SCHEDULED_AT.replace(/Z$/, '').substring(0, 16)
+      : defaultScheduledLocal();
+
+    scheduledInput.addEventListener('change', function () {
+      var isoVal = scheduledInput.value + ':00Z';
+      var text = editArea.value;
+      if (/^scheduledAt:/m.test(text)) {
+        editArea.value = text.replace(/^scheduledAt:.*$/m, 'scheduledAt: ' + isoVal);
+      } else {
+        editArea.value = text.replace(/^(---\\n[\\s\\S]*?)(\\n---)/, '$1\\nscheduledAt: ' + isoVal + '$2');
+      }
+      editArea.dispatchEvent(new Event('input'));
+    });
+  }
+
+  // ── Meta row: postId copy ──────────────────────────
+  var POST_ID_TEXT = ${JSON.stringify(postId ?? '—')};
+  var postIdEl = document.getElementById('meta-postid');
+  if (postIdEl && POST_ID_TEXT !== '—') {
+    postIdEl.style.cursor = 'pointer';
+    postIdEl.addEventListener('click', function () {
+      navigator.clipboard.writeText(POST_ID_TEXT).then(function () {
+        postIdEl.textContent = 'Copied!';
+        setTimeout(function () { postIdEl.textContent = POST_ID_TEXT; }, 1200);
+      }).catch(function () {});
+    });
+  }
+
+  setMode(mode);
+  wireCopyButtons();
+}());`;
+}
+
+// ── Public API ────────────────────────────────────────
+
+export function buildHtml(opts: BuildHtmlOptions): string {
+  const { filePath, title, tags, postId, scheduledAt, initialContent, renderedHtml, headings, readingTime, editMode } = opts;
+
+  const initialMode     = editMode ? 'edit' : 'preview';
+  const previewDisplay  = editMode ? 'none' : 'block';
+  const editDisplay     = editMode ? 'flex' : 'none';
+  const toggleText      = editMode ? '\u2190 Preview' : 'Edit';
+  const toggleActive    = editMode ? ' strip-btn--active' : '';
+  const refreshDisplay  = editMode ? '' : 'none';
+  const hintDisplay     = editMode ? '' : 'none';
+
+  const year     = new Date().getFullYear();
+  const basename = filePath.split('/').pop() ?? filePath;
+
+  const tagsHtml   = tags.length > 0
+    ? `<div class="post-tags">${tags.map(buildTagBadge).join('')}</div>`
+    : '';
+  const tocHtml    = buildTocHtml(headings);
+  const navHtml    = buildNavHtml();
+  const footerHtml = buildFooterHtml(year);
+
+  // Inline theme script in <head> prevents FOUC on reload
+  const themeScript = `(function(){var t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.classList.toggle('dark',t==='dark');})();`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>[DRAFT] ${escapeHtml(title)} \u2014 The Augmented Craftsman</title>
+<style>${CSS}</style>
+<script>${themeScript}<\/script>
+</head>
+<body>
+
+<!-- Editor Strip (fixed, always visible) -->
+<div class="editor-strip">
+  <span class="strip-draft">\u26a0 DRAFT</span>
+  <span class="strip-filepath">${escapeHtml(basename)}</span>
+  <div class="strip-actions">
+    <button id="mode-toggle" class="strip-btn${toggleActive}">${escapeHtml(toggleText)}</button>
+    <button id="refresh-btn" class="strip-btn" style="display:${refreshDisplay}">Refresh</button>
+    <span id="save-status" class="strip-save-status"></span>
+    <span id="cmd-hint" class="strip-cmd-hint" style="display:${hintDisplay}">Cmd+S to refresh</span>
+  </div>
+</div>
+
+<!-- Page Chrome (preview mode) -->
+<div id="page-chrome" style="display:${previewDisplay}">
+
+  ${navHtml}
+
+  <article class="post-article">
+    <div class="post-inner">
+
+      <header class="post-header">
+        <a href="/blog" class="back-link">
+          <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path d="M19 12H5M12 19l-7-7 7-7"/>
+          </svg>
+          Back to all posts
+        </a>
+
+        <div class="post-meta">
+          <span>Draft</span>
+          <span class="post-meta-dot"></span>
+          <span>${escapeHtml(readingTime)}</span>
+        </div>
+
+        <h1 class="post-title-display">${escapeHtml(title)}</h1>
+
+        ${tagsHtml}
+      </header>
+
+      <div class="post-content">
+        <div class="prose-wrapper">
+          <div id="prose-content" class="prose-forge">${renderedHtml}</div>
+        </div>
+        ${tocHtml}
+      </div>
+
+      <footer class="post-footer">
+        <div class="post-footer-inner">
+          <div>
+            <p class="post-author-title">Written by <strong>Christian Borrello</strong></p>
+            <p class="post-author-role">Software Engineer &middot; Craftsman &middot; Lifelong Learner</p>
+          </div>
+          <a href="/blog" class="more-posts-link">More posts &rarr;</a>
+        </div>
+      </footer>
+
+      <div class="comments-section">
+        <h3 class="comments-heading">Comments</h3>
+        <div class="comment-signin">
+          <p class="comments-subtitle">Join the conversation</p>
+          <p class="comments-note">Sign in to leave a comment on this post.</p>
+          <div class="oauth-buttons">
+            <button class="oauth-btn" disabled>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/></svg>
+              Sign in with GitHub
+            </button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </article>
+
+  ${footerHtml}
+
+</div>
+
+<!-- Edit Container -->
+<div id="edit-container" class="edit-container" style="display:${editDisplay}">
+
+  <div class="md-toolbar" id="md-toolbar">
+    <div class="md-toolbar-group">
+      <button class="md-btn" data-action="h1" title="Heading 1 (Cmd+1)">H1</button>
+      <button class="md-btn" data-action="h2" title="Heading 2 (Cmd+2)">H2</button>
+      <button class="md-btn" data-action="h3" title="Heading 3 (Cmd+3)">H3</button>
+    </div>
+    <span class="md-toolbar-sep"></span>
+    <div class="md-toolbar-group">
+      <button class="md-btn" data-action="bold"   title="Bold (Cmd+B)"><strong>B</strong></button>
+      <button class="md-btn" data-action="italic" title="Italic (Cmd+I)"><em>I</em></button>
+      <button class="md-btn" data-action="code"   title="Inline code (Cmd+E)">&#96;c&#96;</button>
+    </div>
+    <span class="md-toolbar-sep"></span>
+    <div class="md-toolbar-group">
+      <button class="md-btn" data-action="codeblock" title="Code block">&#96;&#96;&#96;</button>
+      <button class="md-btn" data-action="link"      title="Link (Cmd+K)">[L]</button>
+      <button class="md-btn" data-action="quote"     title="Blockquote">&gt;</button>
+      <button class="md-btn" data-action="hr"        title="Horizontal rule">—</button>
+    </div>
+  </div>
+
+  <div class="editor-meta-row" id="editor-meta-row">
+    <span class="meta-label">Post ID</span>
+    <span class="meta-postid" id="meta-postid" title="${postId ? 'Click to copy' : ''}">${escapeHtml(postId ?? '—')}</span>
+    <span class="meta-sep">·</span>
+    <label class="meta-label" for="scheduled-input">Scheduled</label>
+    <input type="datetime-local" id="scheduled-input" class="meta-datetime">
+  </div>
+
+  <textarea id="edit-area" class="editor-textarea" spellcheck="false"
+  >${escapeHtml(initialContent)}</textarea>
+
+  <div class="editor-statusbar" id="editor-statusbar">
+    <span id="status-words">0 words</span>
+    <span class="status-sep">·</span>
+    <span id="status-read-time">~1 min read</span>
+    <span class="status-sep">·</span>
+    <span id="status-cursor">1:1</span>
+    <span class="status-right">Cmd+B/I/E · Cmd+S = preview</span>
+  </div>
+
+</div>
+
+<script>${buildScript(filePath, initialMode, postId, scheduledAt)}<\/script>
+</body>
+</html>`;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,8 +19,12 @@
         "tailwindcss": "^3.4.0",
         "typescript": "^5.9.3"
       },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "tsx": "^4.21.0"
+      },
       "engines": {
-        "node": ">=24"
+        "node": "24"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2884,6 +2888,16 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -4672,6 +4686,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-slugger": {
@@ -7061,6 +7088,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -7744,6 +7781,26 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -7800,6 +7857,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,12 +3,17 @@
   "type": "module",
   "version": "0.1.0",
   "engines": {
-    "node": ">=24"
+    "node": "24"
   },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "editor": "tsx editor-server.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.21.0"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.6",

--- a/frontend/src/components/PostEditor.tsx
+++ b/frontend/src/components/PostEditor.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+interface Props {
+  filePath: string;
+  initialContent: string;
+  renderedHtml: string;
+  editMode?: boolean;
+}
+
+type Mode = 'preview' | 'edit';
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+function getApiBase(): string {
+  return document.querySelector<HTMLMetaElement>('meta[name="api-base"]')?.content || 'http://localhost:5063';
+}
+
+const ADMIN_KEY = 'dev-admin-key';
+const DEBOUNCE_MS = 1500;
+
+export default function PostEditor({ filePath, initialContent, renderedHtml, editMode = false }: Props) {
+  const [mode, setMode] = useState<Mode>(editMode ? 'edit' : 'preview');
+  const [content, setContent] = useState(initialContent);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+
+  // Populate the preview div once using DOM APIs (trusted SSR output from Shiki+remark)
+  useEffect(() => {
+    if (!previewRef.current) return;
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(renderedHtml, 'text/html');
+    const nodes = Array.from(doc.body.childNodes);
+    previewRef.current.replaceChildren(...nodes);
+  }, [renderedHtml]);
+
+  const save = useCallback(async (text: string): Promise<boolean> => {
+    setSaveStatus('saving');
+    try {
+      const res = await fetch(`${getApiBase()}/local/file`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': ADMIN_KEY,
+        },
+        body: JSON.stringify({ filePath, content: text }),
+      });
+      if (res.ok) {
+        setSaveStatus('saved');
+        return true;
+      }
+      setSaveStatus('error');
+      return false;
+    } catch {
+      setSaveStatus('error');
+      return false;
+    }
+  }, [filePath]);
+
+  const scheduleAutoSave = useCallback((text: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => save(text), DEBOUNCE_MS);
+  }, [save]);
+
+  const handleChange = useCallback((e: Event) => {
+    const text = (e.target as HTMLTextAreaElement).value;
+    setContent(text);
+    setSaveStatus('idle');
+    scheduleAutoSave(text);
+  }, [scheduleAutoSave]);
+
+  const refreshPreview = useCallback(async (text: string) => {
+    try {
+      const res = await fetch('/api/render', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: text }),
+      });
+      if (!res.ok) return;
+      const { html } = await res.json();
+      if (!previewRef.current) return;
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      previewRef.current.replaceChildren(...Array.from(doc.body.childNodes));
+      setMode('preview');
+    } catch {
+      // silently fail — user stays in edit mode
+    }
+  }, []);
+
+  useEffect(() => {
+    if (mode !== 'edit') return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault();
+        refreshPreview(content);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [mode, content, refreshPreview]);
+
+  useEffect(() => {
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, []);
+
+  const statusLabel: Record<SaveStatus, string> = {
+    idle: '',
+    saving: 'Saving…',
+    saved: 'Saved ✓',
+    error: 'Error ✗',
+  };
+
+  const statusColor: Record<SaveStatus, string> = {
+    idle: 'transparent',
+    saving: 'var(--color-text-muted)',
+    saved: '#4ade80',
+    error: 'var(--color-accent)',
+  };
+
+  return (
+    <div>
+      {/* Toolbar */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.75rem',
+        marginBottom: '1.5rem',
+        padding: '0.5rem 0.75rem',
+        background: 'var(--color-surface)',
+        border: '1px solid var(--color-border)',
+        borderRadius: '0.375rem',
+        fontFamily: 'var(--font-mono)',
+        fontSize: '0.75rem',
+      }}>
+        <button
+          onClick={() => setMode(mode === 'edit' ? 'preview' : 'edit')}
+          style={{
+            padding: '0.25rem 0.75rem',
+            background: mode === 'edit' ? 'var(--color-accent)' : 'var(--color-surface)',
+            color: mode === 'edit' ? 'var(--color-bg)' : 'var(--color-text)',
+            border: '1px solid var(--color-border)',
+            borderRadius: '0.25rem',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            fontWeight: 600,
+          }}
+        >
+          {mode === 'edit' ? '\u2190 Preview' : 'Edit'}
+        </button>
+
+        {mode === 'edit' && (
+          <button
+            onClick={() => refreshPreview(content)}
+            style={{
+              padding: '0.25rem 0.75rem',
+              background: 'var(--color-surface)',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-border)',
+              borderRadius: '0.25rem',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              fontSize: 'inherit',
+            }}
+          >
+            Refresh Preview
+          </button>
+        )}
+
+        {mode === 'edit' && saveStatus !== 'idle' && (
+          <span style={{ color: statusColor[saveStatus], marginLeft: 'auto' }}>
+            {statusLabel[saveStatus]}
+          </span>
+        )}
+
+        {mode === 'edit' && (
+          <span style={{ color: 'var(--color-text-muted)', marginLeft: saveStatus === 'idle' ? 'auto' : '0' }}>
+            Cmd+S to refresh preview
+          </span>
+        )}
+      </div>
+
+      {/* Preview div — always in DOM, populated once via DOMParser, hidden in edit mode */}
+      <div
+        ref={previewRef}
+        class="prose-forge"
+        style={{ display: mode === 'preview' ? 'block' : 'none' }}
+      />
+
+      {/* Edit textarea — only mounted in edit mode */}
+      {mode === 'edit' && (
+        <textarea
+          value={content}
+          onInput={handleChange}
+          spellcheck={false}
+          style={{
+            width: '100%',
+            minHeight: '70vh',
+            padding: '1rem',
+            background: 'var(--color-surface)',
+            color: 'var(--color-text)',
+            border: '1px solid var(--color-border)',
+            borderRadius: '0.375rem',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.875rem',
+            lineHeight: '1.6',
+            resize: 'vertical',
+            outline: 'none',
+            boxSizing: 'border-box',
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/api/render.ts
+++ b/frontend/src/pages/api/render.ts
@@ -1,0 +1,21 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { renderMarkdown } from '../../data/markdown';
+
+export const POST: APIRoute = async ({ request }) => {
+  if (import.meta.env.PROD) {
+    return new Response('Not available in production', { status: 403 });
+  }
+
+  const { content } = await request.json();
+
+  // Strip YAML frontmatter — same logic as preview.astro
+  const match = (content as string).match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)$/);
+  const body = match?.[1] ?? (content as string);
+
+  const html = await renderMarkdown(body);
+  return new Response(JSON.stringify({ html }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/frontend/src/pages/preview.astro
+++ b/frontend/src/pages/preview.astro
@@ -1,0 +1,92 @@
+---
+export const prerender = false;
+
+import { readFileSync } from 'node:fs';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import TagBadge from '../components/TagBadge.astro';
+import PostEditor from '../components/PostEditor.tsx';
+import { renderMarkdown } from '../data/markdown';
+
+// Block access in production builds
+if (import.meta.env.PROD) {
+  return Astro.redirect('/404');
+}
+
+const filePath = Astro.url.searchParams.get('file');
+
+if (!filePath) {
+  return Astro.redirect('/404');
+}
+
+let raw: string;
+try {
+  raw = readFileSync(filePath, 'utf-8');
+} catch {
+  return Astro.redirect('/404');
+}
+
+// Strip YAML frontmatter and extract metadata
+const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+const yaml = match?.[1] ?? '';
+const body = match?.[2] ?? raw;
+
+const titleMatch = yaml.match(/^title:\s*["']?(.+?)["']?\s*$/m);
+const tagsMatch = yaml.match(/^tags:\s*\[([^\]]*)\]/m);
+
+const title = titleMatch?.[1] ?? 'Untitled Preview';
+const tags: string[] = tagsMatch?.[1]
+  ? tagsMatch[1].split(',').map(t => t.trim()).filter(Boolean)
+  : [];
+
+const contentHtml = await renderMarkdown(body);
+const editMode = Astro.url.searchParams.has('edit');
+---
+
+<BaseLayout title={`[PREVIEW] ${title} — The Augmented Craftsman`}>
+
+  <article class="px-6 md:px-10 max-w-wide mx-auto pt-12 md:pt-20">
+    <div class="max-w-4xl mx-auto">
+
+      <header class="mb-12 md:mb-16 animate-fade-up">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded font-mono text-xs font-bold uppercase tracking-widest mb-6"
+             style="background: var(--color-accent); color: var(--color-bg);">
+          ⚠ PREVIEW — not published
+        </div>
+
+        <div class="flex items-center gap-3 text-body-sm font-mono text-[var(--color-text-muted)] mb-4">
+          <span class="font-mono text-xs">Local file: {filePath}</span>
+        </div>
+
+        <h1 class="font-display font-semibold text-display-lg md:text-display-xl text-balance">
+          {title}
+        </h1>
+
+        {tags.length > 0 && (
+          <div class="flex flex-wrap gap-2 mt-6">
+            {tags.map((tag) => (
+              <TagBadge tag={tag} size="md" />
+            ))}
+          </div>
+        )}
+      </header>
+
+      <div class="flex-1 min-w-0 animate-fade-up" style="animation-delay: 150ms;">
+        <PostEditor
+          filePath={filePath}
+          initialContent={raw}
+          renderedHtml={contentHtml}
+          editMode={editMode}
+          client:load
+        />
+      </div>
+
+      <footer class="mt-16 pt-8 border-t border-[var(--color-border)]">
+        <p class="font-mono text-xs text-[var(--color-text-muted)]">
+          Preview only — Cmd+S or "Refresh Preview" to re-render in place (no page reload)
+        </p>
+      </footer>
+
+    </div>
+  </article>
+
+</BaseLayout>


### PR DESCRIPTION
## Summary

- **Editor UI**: meta-row between toolbar and textarea showing `postId` (read-only, click-to-copy) and `scheduledAt` as a `datetime-local` picker — pre-filled from frontmatter or defaulting to tomorrow 9AM local; picker changes sync back into the frontmatter textarea and trigger autosave
- **`tac post new`**: new CLI command that creates a draft via API then generates a `.md` file with full YAML frontmatter (`postId`, `scheduledAt`, `title`, `tags`)
- **`tac post schedule`**: new CLI command that generates a GitHub Actions workflow YAML for future publishing via cron
- **`tac post create --file`**: extended to accept `.md` files with YAML frontmatter; writes `postId` back after creation
- **`FrontmatterParser`**: new C# helper for reading/writing YAML frontmatter using YamlDotNet
- **`LocalEndpoints`**: registered only in Development for local editor integration
- **Frontend**: added `tsx` devDep, `npm run editor` script, `PostEditor` component, `preview.astro` page, `/api/render` endpoint

## Test plan

- [ ] `tac post new --title "Test" --tag tdd` → creates `.md` in `docs/posts/drafts/`, file has `postId` and `scheduledAt`
- [ ] Open the generated file in the standalone editor: meta-row visible with postId (click copies to clipboard) and picker showing the scheduled date
- [ ] Open a file without `scheduledAt` → picker defaults to tomorrow 9AM local
- [ ] Change date in picker → frontmatter in textarea updates in real-time, autosave fires after 1.5s
- [ ] `tac post schedule <id> --at "2026-04-01T09:00:00Z"` → workflow YAML created in `.github/workflows/`
- [ ] `dotnet build` passes with no warnings on backend
- [ ] `npm run build` passes on frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)