### PR TITLE
Fix like counter and add comment counter to post cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ StrykerOutput/
 docs/
 backend/docs/
 scripts/
+!frontend/public/scripts/
 tac-ui.sh
 CLAUDE.md
 BEST_PRACTICES.md

--- a/frontend/public/scripts/postcard-counts.js
+++ b/frontend/public/scripts/postcard-counts.js
@@ -1,0 +1,31 @@
+function fetchPostCardCounts() {
+  var apiBase = document.querySelector('meta[name="api-base"]');
+  if (!apiBase) return;
+  var api = apiBase.getAttribute('content');
+  document.querySelectorAll('.postcard-likes[data-slug]').forEach(function(el) {
+    var slug = el.getAttribute('data-slug');
+    if (!slug) return;
+    var card = el.closest('article');
+
+    fetch(api + '/api/posts/' + slug + '/likes/count')
+      .then(function(res) { return res.ok ? res.json() : null; })
+      .then(function(data) {
+        if (!data) return;
+        var countEl = el.querySelector('.postcard-like-count');
+        if (countEl) countEl.textContent = String(data.count ?? data);
+      })
+      .catch(function() {});
+
+    if (!card) return;
+    fetch(api + '/api/posts/' + slug + '/comments/count')
+      .then(function(res) { return res.ok ? res.json() : null; })
+      .then(function(data) {
+        if (!data) return;
+        var countEl = card.querySelector('.postcard-comment-count');
+        if (countEl) countEl.textContent = String(data.count ?? data);
+      })
+      .catch(function() {});
+  });
+}
+fetchPostCardCounts();
+document.addEventListener('astro:after-swap', fetchPostCardCounts);

--- a/frontend/src/components/PostCard.astro
+++ b/frontend/src/components/PostCard.astro
@@ -43,6 +43,13 @@ const formattedDate = new Date(date).toLocaleDateString('en-US', {
         </svg>
         <span class="postcard-like-count">—</span>
       </span>
+      <span class="w-1 h-1 rounded-full bg-[var(--color-text-muted)]"></span>
+      <span class="postcard-comments">
+        <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        <span class="postcard-comment-count">—</span>
+      </span>
     </div>
 
     <!-- Title -->

--- a/frontend/src/pages/blog/index.astro
+++ b/frontend/src/pages/blog/index.astro
@@ -60,26 +60,6 @@ const allTags = (() => {
     </p>
   </div>
 
-<script is:inline>
-  function fetchLikeCounts() {
-    var apiBase = document.querySelector('meta[name="api-base"]');
-    if (!apiBase) return;
-    var api = apiBase.getAttribute('content');
-    document.querySelectorAll('.postcard-likes[data-slug]').forEach(function(el) {
-      var slug = el.getAttribute('data-slug');
-      if (!slug) return;
-      fetch(api + '/api/posts/' + slug + '/likes')
-        .then(function(res) { return res.ok ? res.json() : null; })
-        .then(function(data) {
-          if (!data) return;
-          var countEl = el.querySelector('.postcard-like-count');
-          if (countEl) countEl.textContent = String(data.count ?? data);
-        })
-        .catch(function() {});
-    });
-  }
-  fetchLikeCounts();
-  document.addEventListener('astro:after-swap', fetchLikeCounts);
-</script>
+<script is:inline src="/scripts/postcard-counts.js"></script>
 
 </BaseLayout>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -123,26 +123,6 @@ const topTags = (await fetchTags()).slice(0, 6);
     </div>
   </section>
 
-<script is:inline>
-  function fetchLikeCounts() {
-    var apiBase = document.querySelector('meta[name="api-base"]');
-    if (!apiBase) return;
-    var api = apiBase.getAttribute('content');
-    document.querySelectorAll('.postcard-likes[data-slug]').forEach(function(el) {
-      var slug = el.getAttribute('data-slug');
-      if (!slug) return;
-      fetch(api + '/api/posts/' + slug + '/likes')
-        .then(function(res) { return res.ok ? res.json() : null; })
-        .then(function(data) {
-          if (!data) return;
-          var countEl = el.querySelector('.postcard-like-count');
-          if (countEl) countEl.textContent = String(data.count ?? data);
-        })
-        .catch(function() {});
-    });
-  }
-  fetchLikeCounts();
-  document.addEventListener('astro:after-swap', fetchLikeCounts);
-</script>
+<script is:inline src="/scripts/postcard-counts.js"></script>
 
 </BaseLayout>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -589,16 +589,18 @@
   }
 }
 
-/* --- Post Card like count --- */
+/* --- Post Card engagement counters --- */
 
 @layer components {
-  .postcard-likes {
+  .postcard-likes,
+  .postcard-comments {
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
   }
 
-  .postcard-likes svg {
+  .postcard-likes svg,
+  .postcard-comments svg {
     width: 12px;
     height: 12px;
     color: var(--color-text-muted);


### PR DESCRIPTION
## Summary
- **Bug fix**: Like counter showed "—" because frontend fetched `/likes` (POST-only endpoint, returns 405) instead of `/likes/count`
- **Feature**: Added comment counter (chat-bubble icon + count) to post preview cards, using the existing `/comments/count` backend endpoint
- **Refactor**: Extracted duplicated fetch script from `index.astro` and `blog/index.astro` into shared `public/scripts/postcard-counts.js`

Closes #26

> View/read counter deferred to #29

## Test plan
- [x] `npm run build` passes
- [x] Like counters show actual numbers instead of "—"
- [x] Comment counters appear with correct count
- [x] Counters load on both home page and blog listing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)