### PR TITLE
fix(frontend): fix TOC scroll-spy flickering and anchor offset

### DIFF
--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -45,7 +45,7 @@ const canonicalUrl = new URL(`/blog/${post.slug}`, Astro.site).href;
   <article class="px-6 md:px-10 max-w-wide mx-auto pt-12 md:pt-20">
     <div class="max-w-4xl mx-auto">
 
-      <header id="article-top" class="mb-12 md:mb-16 animate-fade-up">
+      <header id="article-top" class="mb-12 md:mb-16 animate-fade-up scroll-mt-24">
         <a href="/blog" class="inline-flex items-center gap-2 text-body-sm font-mono text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors mb-8">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path d="M19 12H5M12 19l-7-7 7-7" />
@@ -127,7 +127,7 @@ const canonicalUrl = new URL(`/blog/${post.slug}`, Astro.site).href;
       </footer>
 
       <CommentList server:defer slug={post.slug} pageUrl={canonicalUrl}>
-        <div slot="fallback" class="comment-skeleton">
+        <div slot="fallback" class="comment-skeleton" style="min-height: 12rem;">
           <div class="comment-skeleton-bar" style="width: 40%; height: 1.5rem; margin-bottom: 1.5rem;"></div>
           <div class="comment-skeleton-bar" style="width: 100%; height: 5rem; margin-bottom: 1rem;"></div>
           <div class="comment-skeleton-bar" style="width: 80%; height: 0.75rem; margin-bottom: 0.5rem;"></div>
@@ -187,15 +187,32 @@ const canonicalUrl = new URL(`/blog/${post.slug}`, Astro.site).href;
 </script>
 
 <script>
+  let scrollSpyObserver: IntersectionObserver | null = null;
+
   function initScrollSpy() {
+    scrollSpyObserver?.disconnect();
+
     const tocLinks = document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]');
     if (!tocLinks.length) return;
 
     const introLink = document.querySelector<HTMLAnchorElement>('[data-toc-link="article-top"]');
     const headings = document.querySelectorAll('.prose-forge h2[id]');
     const visibleHeadings = new Set<string>();
+    let lastActiveId: string | null = null;
 
-    const observer = new IntersectionObserver(
+    function activate(id: string | null) {
+      tocLinks.forEach(link => link.classList.remove('active'));
+      if (id) {
+        document.querySelector<HTMLAnchorElement>(`[data-toc-link="${id}"]`)?.classList.add('active');
+      } else {
+        introLink?.classList.add('active');
+      }
+      lastActiveId = id;
+    }
+
+    activate(null);
+
+    scrollSpyObserver = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
@@ -207,19 +224,20 @@ const canonicalUrl = new URL(`/blog/${post.slug}`, Astro.site).href;
 
         if (visibleHeadings.size > 0) {
           const firstVisible = Array.from(headings).find(h => visibleHeadings.has(h.id));
-          if (firstVisible) {
-            tocLinks.forEach(link => link.classList.remove('active'));
-            document.querySelector<HTMLAnchorElement>(`[data-toc-link="${firstVisible.id}"]`)?.classList.add('active');
-          }
-        } else {
-          tocLinks.forEach(link => link.classList.remove('active'));
-          introLink?.classList.add('active');
+          if (firstVisible) activate(firstVisible.id);
+          return;
+        }
+
+        if (lastActiveId && headings.length > 0) {
+          const firstHeading = headings[0] as HTMLElement;
+          const aboveFirstHeading = firstHeading.getBoundingClientRect().top > window.innerHeight * 0.4;
+          if (aboveFirstHeading) activate(null);
         }
       },
       { rootMargin: '0px 0px -60% 0px' }
     );
 
-    headings.forEach(heading => observer.observe(heading));
+    headings.forEach(heading => scrollSpyObserver!.observe(heading));
   }
 
   initScrollSpy();

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -93,6 +93,7 @@
     margin-top: 3rem;
     margin-bottom: 1rem;
     color: var(--color-text);
+    scroll-margin-top: 6rem;
   }
 
   .prose-forge h3 {
@@ -102,6 +103,7 @@
     letter-spacing: -0.015em;
     margin-top: 2.5rem;
     margin-bottom: 0.75rem;
+    scroll-margin-top: 6rem;
   }
 
   .prose-forge p {


### PR DESCRIPTION
## Summary
- Fix TOC "On this page" sidebar flickering back to "Introduzione" when scrolling between headings
- Add `lastActiveId` state to persist the active heading when no h2 is in the observed zone
- Disconnect previous `IntersectionObserver` before re-init to prevent ghost observers across View Transitions
- Add `scroll-margin-top` to headings so TOC anchor clicks don't hide content behind the sticky navbar
- Add `min-height` to comment skeleton to reduce layout shift that re-triggered the observer

## Test plan
- [x] Open a post with multiple headings
- [x] Scroll down — TOC highlights the correct section without flickering
- [x] Click a TOC heading — page scrolls with content visible below the navbar
- [x] Navigate between posts (View Transitions) — TOC works correctly on each post
- [x] Frontend builds successfully (`npm run build`)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)