### PR TITLE
feat(frontend): add RSS feed with auto-discovery

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.6",
         "@astrojs/preact": "^4.1.3",
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/tailwind": "^5.1.0",
         "@astrojs/vercel": "^9.0.4",
         "astro": "^5.5.0",
@@ -281,6 +282,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -4532,6 +4553,41 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6493,6 +6549,21 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7527,6 +7598,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.6",
     "@astrojs/preact": "^4.1.3",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/tailwind": "^5.1.0",
     "@astrojs/vercel": "^9.0.4",
     "astro": "^5.5.0",

--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -33,6 +33,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta name="twitter:description" content={description} />
 
     <link rel="canonical" href={canonicalURL} />
+    <link rel="alternate" type="application/rss+xml" title="The Augmented Craftsman" href="/rss.xml" />
     <link rel="icon" type="image/png" href="/assets/tac-logo.png" />
     <meta name="api-base" content={import.meta.env.PUBLIC_API_URL || 'http://localhost:5063'} />
 

--- a/frontend/src/pages/rss.xml.ts
+++ b/frontend/src/pages/rss.xml.ts
@@ -1,0 +1,20 @@
+import type { APIContext } from 'astro';
+import rss from '@astrojs/rss';
+import { fetchPosts } from '../data/api';
+
+export async function GET(context: APIContext) {
+  const posts = await fetchPosts();
+
+  return rss({
+    title: 'The Augmented Craftsman',
+    description: 'Crafting software with intention — TDD, Clean Architecture, DDD, and the pursuit of elegant code.',
+    site: context.site!.href,
+    items: posts.map(post => ({
+      title: post.title,
+      description: post.excerpt,
+      pubDate: new Date(post.date),
+      link: `/blog/${post.slug}`,
+      categories: post.tags.map(tag => tag.name),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- Add `/rss.xml` endpoint using `@astrojs/rss` — generates valid RSS 2.0 feed from all published posts
- Add `<link rel="alternate">` auto-discovery tag in `BaseLayout.astro` so feed readers detect the feed automatically
- Footer RSS button (already pointing to `/rss.xml`) now works

## Test plan
- [x] `npm run build` generates `rss.xml` in static output
- [x] Feed contains all published posts with correct titles, dates, URLs, and tag categories
- [x] Auto-discovery `<link>` tag present in page `<head>`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)