### PR TITLE
feat: add view/read counter to posts

### DIFF
--- a/backend/src/TacBlog.Api/Endpoints/ViewEndpoints.cs
+++ b/backend/src/TacBlog.Api/Endpoints/ViewEndpoints.cs
@@ -1,0 +1,49 @@
+using TacBlog.Application.Features.Views;
+
+namespace TacBlog.Api.Endpoints;
+
+public static class ViewEndpoints
+{
+    public static void MapViewEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/posts/{slug}/views", RecordViewAsync).AllowAnonymous();
+        app.MapGet("/api/posts/{slug}/views/count", GetViewCountAsync).AllowAnonymous();
+    }
+
+    private static async Task<IResult> RecordViewAsync(
+        string slug,
+        ViewRequest request,
+        RecordPageView recordPageView,
+        CancellationToken cancellationToken)
+    {
+        if (!IsValidVisitorId(request.VisitorId))
+            return Results.BadRequest(new { error = "Invalid visitor identifier" });
+
+        var result = await recordPageView.ExecuteAsync(slug, request.VisitorId, cancellationToken);
+
+        if (result.IsNotFound)
+            return Results.NotFound(new { error = "Post not found" });
+
+        return Results.Ok(new { count = result.Count });
+    }
+
+    private static async Task<IResult> GetViewCountAsync(
+        string slug,
+        GetPageViewCount getPageViewCount,
+        CancellationToken cancellationToken)
+    {
+        var result = await getPageViewCount.ExecuteAsync(slug, cancellationToken);
+
+        if (result.IsNotFound)
+            return Results.NotFound(new { error = "Post not found" });
+
+        return Results.Ok(new { count = result.Count });
+    }
+
+    private static bool IsValidVisitorId(string? visitorId) =>
+        !string.IsNullOrWhiteSpace(visitorId)
+        && Guid.TryParse(visitorId, out var parsed)
+        && parsed != Guid.Empty;
+}
+
+public sealed record ViewRequest(string VisitorId);

--- a/backend/src/TacBlog.Api/Program.cs
+++ b/backend/src/TacBlog.Api/Program.cs
@@ -9,6 +9,7 @@ using TacBlog.Application.Features.Comments;
 using TacBlog.Application.Features.Likes;
 using TacBlog.Application.Features.OAuth;
 using TacBlog.Application.Features.Tags;
+using TacBlog.Application.Features.Views;
 using TacBlog.Application.Ports.Driven;
 using TacBlog.Infrastructure;
 using TacBlog.Infrastructure.Clock;
@@ -68,6 +69,9 @@ builder.Services.AddScoped<GetComments>();
 builder.Services.AddScoped<GetCommentCount>();
 builder.Services.AddScoped<DeleteComment>();
 builder.Services.AddScoped<ListAdminComments>();
+builder.Services.AddScoped<IPageViewRepository, EfPageViewRepository>();
+builder.Services.AddScoped<RecordPageView>();
+builder.Services.AddScoped<GetPageViewCount>();
 builder.Services.AddScoped<IReaderSessionRepository, EfReaderSessionRepository>();
 
 var oauthSettings = new TacBlog.Infrastructure.Identity.OAuthSettings(
@@ -163,6 +167,7 @@ app.MapPostEndpoints();
 app.MapTagEndpoints();
 app.MapImageEndpoints();
 app.MapLikeEndpoints();
+app.MapViewEndpoints();
 app.MapCommentEndpoints();
 app.MapOAuthEndpoints();
 

--- a/backend/src/TacBlog.Application/Features/Views/GetPageViewCount.cs
+++ b/backend/src/TacBlog.Application/Features/Views/GetPageViewCount.cs
@@ -1,0 +1,27 @@
+using TacBlog.Application.Ports.Driven;
+using TacBlog.Domain;
+
+namespace TacBlog.Application.Features.Views;
+
+public sealed record GetPageViewCountResult(bool IsNotFound, int Count)
+{
+    public static GetPageViewCountResult Success(int count) => new(false, count);
+    public static GetPageViewCountResult NotFound() => new(true, 0);
+}
+
+public sealed class GetPageViewCount(IBlogPostRepository postRepository, IPageViewRepository viewRepository)
+{
+    public async Task<GetPageViewCountResult> ExecuteAsync(
+        string slugValue,
+        CancellationToken cancellationToken = default)
+    {
+        var slug = new Slug(slugValue);
+
+        var post = await postRepository.FindBySlugAsync(slug, cancellationToken);
+        if (post is null)
+            return GetPageViewCountResult.NotFound();
+
+        var count = await viewRepository.CountBySlugAsync(slug, cancellationToken);
+        return GetPageViewCountResult.Success(count);
+    }
+}

--- a/backend/src/TacBlog.Application/Features/Views/RecordPageView.cs
+++ b/backend/src/TacBlog.Application/Features/Views/RecordPageView.cs
@@ -1,0 +1,32 @@
+using TacBlog.Application.Ports.Driven;
+using TacBlog.Domain;
+
+namespace TacBlog.Application.Features.Views;
+
+public sealed record RecordPageViewResult(bool IsNotFound, int Count)
+{
+    public static RecordPageViewResult Success(int count) => new(false, count);
+    public static RecordPageViewResult NotFound() => new(true, 0);
+}
+
+public sealed class RecordPageView(IBlogPostRepository postRepository, IPageViewRepository viewRepository, IClock clock)
+{
+    public async Task<RecordPageViewResult> ExecuteAsync(
+        string slugValue,
+        string visitorIdValue,
+        CancellationToken cancellationToken = default)
+    {
+        var slug = new Slug(slugValue);
+
+        var post = await postRepository.FindBySlugAsync(slug, cancellationToken);
+        if (post is null)
+            return RecordPageViewResult.NotFound();
+
+        var visitorId = new VisitorId(Guid.Parse(visitorIdValue));
+        var pageView = PageView.Create(slug, visitorId, clock.UtcNow);
+        await viewRepository.SaveAsync(pageView, cancellationToken);
+
+        var count = await viewRepository.CountBySlugAsync(slug, cancellationToken);
+        return RecordPageViewResult.Success(count);
+    }
+}

--- a/backend/src/TacBlog.Application/Ports/Driven/IPageViewRepository.cs
+++ b/backend/src/TacBlog.Application/Ports/Driven/IPageViewRepository.cs
@@ -1,0 +1,9 @@
+using TacBlog.Domain;
+
+namespace TacBlog.Application.Ports.Driven;
+
+public interface IPageViewRepository
+{
+    Task SaveAsync(PageView pageView, CancellationToken cancellationToken);
+    Task<int> CountBySlugAsync(Slug slug, CancellationToken cancellationToken);
+}

--- a/backend/src/TacBlog.Domain/PageView.cs
+++ b/backend/src/TacBlog.Domain/PageView.cs
@@ -1,0 +1,20 @@
+namespace TacBlog.Domain;
+
+public sealed class PageView
+{
+    public Guid Id { get; }
+    public Slug PostSlug { get; }
+    public VisitorId VisitorId { get; }
+    public DateTime ViewedAtUtc { get; }
+
+    private PageView(Guid id, Slug postSlug, VisitorId visitorId, DateTime viewedAtUtc)
+    {
+        Id = id;
+        PostSlug = postSlug;
+        VisitorId = visitorId;
+        ViewedAtUtc = viewedAtUtc;
+    }
+
+    public static PageView Create(Slug postSlug, VisitorId visitorId, DateTime viewedAtUtc) =>
+        new(Guid.NewGuid(), postSlug, visitorId, viewedAtUtc);
+}

--- a/backend/src/TacBlog.Infrastructure/Migrations/20260401094935_AddPageViews.Designer.cs
+++ b/backend/src/TacBlog.Infrastructure/Migrations/20260401094935_AddPageViews.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TacBlog.Infrastructure;
@@ -11,9 +12,11 @@ using TacBlog.Infrastructure;
 namespace TacBlog.Infrastructure.Migrations
 {
     [DbContext(typeof(TacBlogDbContext))]
-    partial class TacBlogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260401094935_AddPageViews")]
+    partial class AddPageViews
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TacBlog.Infrastructure/Migrations/20260401094935_AddPageViews.cs
+++ b/backend/src/TacBlog.Infrastructure/Migrations/20260401094935_AddPageViews.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TacBlog.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPageViews : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "page_views",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    post_slug = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    visitor_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    viewed_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_page_views", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_page_views_blog_posts_post_slug",
+                        column: x => x.post_slug,
+                        principalTable: "blog_posts",
+                        principalColumn: "slug",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_page_views_post_slug",
+                table: "page_views",
+                column: "post_slug");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "page_views");
+        }
+    }
+}

--- a/backend/src/TacBlog.Infrastructure/Persistence/EfPageViewRepository.cs
+++ b/backend/src/TacBlog.Infrastructure/Persistence/EfPageViewRepository.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using TacBlog.Application.Ports.Driven;
+using TacBlog.Domain;
+
+namespace TacBlog.Infrastructure.Persistence;
+
+public sealed class EfPageViewRepository(TacBlogDbContext context) : IPageViewRepository
+{
+    public async Task SaveAsync(PageView pageView, CancellationToken cancellationToken)
+    {
+        context.PageViews.Add(pageView);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<int> CountBySlugAsync(Slug slug, CancellationToken cancellationToken) =>
+        await context.PageViews.CountAsync(v => v.PostSlug == slug, cancellationToken);
+}

--- a/backend/src/TacBlog.Infrastructure/Persistence/PageViewConfiguration.cs
+++ b/backend/src/TacBlog.Infrastructure/Persistence/PageViewConfiguration.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TacBlog.Domain;
+
+namespace TacBlog.Infrastructure.Persistence;
+
+public sealed class PageViewConfiguration : IEntityTypeConfiguration<PageView>
+{
+    public void Configure(EntityTypeBuilder<PageView> builder)
+    {
+        builder.ToTable("page_views");
+
+        builder.HasKey(v => v.Id);
+
+        builder.Property(v => v.Id)
+            .HasColumnName("id");
+
+        builder.Property(v => v.PostSlug)
+            .HasColumnName("post_slug")
+            .HasMaxLength(250)
+            .IsRequired()
+            .HasConversion(
+                slug => slug.Value,
+                value => new Slug(value));
+
+        builder.Property(v => v.VisitorId)
+            .HasColumnName("visitor_id")
+            .IsRequired()
+            .HasConversion(
+                id => id.Value,
+                guid => new VisitorId(guid));
+
+        builder.Property(v => v.ViewedAtUtc)
+            .HasColumnName("viewed_at_utc")
+            .IsRequired();
+
+        builder.HasOne<BlogPost>()
+            .WithMany()
+            .HasForeignKey(v => v.PostSlug)
+            .HasPrincipalKey(p => p.Slug)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/TacBlog.Infrastructure/Persistence/TacBlogDbContext.cs
+++ b/backend/src/TacBlog.Infrastructure/Persistence/TacBlogDbContext.cs
@@ -11,6 +11,7 @@ public sealed class TacBlogDbContext(DbContextOptions<TacBlogDbContext> options)
     public DbSet<Like> Likes => Set<Like>();
     public DbSet<Comment> Comments => Set<Comment>();
     public DbSet<ReaderSession> ReaderSessions => Set<ReaderSession>();
+    public DbSet<PageView> PageViews => Set<PageView>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -19,5 +20,6 @@ public sealed class TacBlogDbContext(DbContextOptions<TacBlogDbContext> options)
         modelBuilder.ApplyConfiguration(new LikeConfiguration());
         modelBuilder.ApplyConfiguration(new CommentConfiguration());
         modelBuilder.ApplyConfiguration(new ReaderSessionConfiguration());
+        modelBuilder.ApplyConfiguration(new PageViewConfiguration());
     }
 }

--- a/backend/tests/TacBlog.Application.Tests/Features/Views/GetPageViewCountShould.cs
+++ b/backend/tests/TacBlog.Application.Tests/Features/Views/GetPageViewCountShould.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NSubstitute;
+using TacBlog.Application.Features.Views;
+using TacBlog.Application.Ports.Driven;
+using TacBlog.Domain;
+using Xunit;
+
+namespace TacBlog.Application.Tests.Features.Views;
+
+public class GetPageViewCountShould
+{
+    private readonly IBlogPostRepository _postRepository = Substitute.For<IBlogPostRepository>();
+    private readonly IPageViewRepository _viewRepository = Substitute.For<IPageViewRepository>();
+    private readonly GetPageViewCount _useCase;
+
+    public GetPageViewCountShould()
+    {
+        _useCase = new GetPageViewCount(_postRepository, _viewRepository);
+    }
+
+    [Fact]
+    public async Task return_count_when_post_exists()
+    {
+        var slug = new Slug("my-post");
+
+        _postRepository.FindBySlugAsync(slug, Arg.Any<CancellationToken>())
+            .Returns(BlogPost.Create(new Title("My Post"), new PostContent("Content"), DateTime.UtcNow));
+        _viewRepository.CountBySlugAsync(slug, Arg.Any<CancellationToken>())
+            .Returns(42);
+
+        var result = await _useCase.ExecuteAsync(slug.Value);
+
+        result.IsNotFound.Should().BeFalse();
+        result.Count.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task return_not_found_when_post_does_not_exist()
+    {
+        var slug = new Slug("non-existent");
+
+        _postRepository.FindBySlugAsync(slug, Arg.Any<CancellationToken>())
+            .Returns((BlogPost?)null);
+
+        var result = await _useCase.ExecuteAsync(slug.Value);
+
+        result.IsNotFound.Should().BeTrue();
+        result.Count.Should().Be(0);
+    }
+}

--- a/backend/tests/TacBlog.Application.Tests/Features/Views/RecordPageViewShould.cs
+++ b/backend/tests/TacBlog.Application.Tests/Features/Views/RecordPageViewShould.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using NSubstitute;
+using TacBlog.Application.Features.Views;
+using TacBlog.Application.Ports.Driven;
+using TacBlog.Domain;
+using Xunit;
+
+namespace TacBlog.Application.Tests.Features.Views;
+
+public class RecordPageViewShould
+{
+    private static readonly DateTime FixedNow = new(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc);
+
+    private readonly IBlogPostRepository _postRepository = Substitute.For<IBlogPostRepository>();
+    private readonly IPageViewRepository _viewRepository = Substitute.For<IPageViewRepository>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly RecordPageView _useCase;
+
+    public RecordPageViewShould()
+    {
+        _clock.UtcNow.Returns(FixedNow);
+        _useCase = new RecordPageView(_postRepository, _viewRepository, _clock);
+    }
+
+    [Fact]
+    public async Task save_view_and_return_count_when_post_exists()
+    {
+        var slug = new Slug("my-post");
+        var visitorId = Guid.NewGuid().ToString();
+
+        _postRepository.FindBySlugAsync(slug, Arg.Any<CancellationToken>())
+            .Returns(BlogPost.Create(new Title("My Post"), new PostContent("Content"), FixedNow));
+        _viewRepository.CountBySlugAsync(slug, Arg.Any<CancellationToken>())
+            .Returns(5);
+
+        var result = await _useCase.ExecuteAsync(slug.Value, visitorId);
+
+        result.IsNotFound.Should().BeFalse();
+        result.Count.Should().Be(5);
+        await _viewRepository.Received(1).SaveAsync(Arg.Any<PageView>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task return_not_found_when_post_does_not_exist()
+    {
+        var slug = new Slug("non-existent");
+
+        _postRepository.FindBySlugAsync(slug, Arg.Any<CancellationToken>())
+            .Returns((BlogPost?)null);
+
+        var result = await _useCase.ExecuteAsync(slug.Value, Guid.NewGuid().ToString());
+
+        result.IsNotFound.Should().BeTrue();
+        result.Count.Should().Be(0);
+        await _viewRepository.DidNotReceive().SaveAsync(Arg.Any<PageView>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/tests/TacBlog.Domain.Tests/PageViewShould.cs
+++ b/backend/tests/TacBlog.Domain.Tests/PageViewShould.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using TacBlog.Domain;
+using Xunit;
+
+namespace TacBlog.Domain.Tests;
+
+public class PageViewShould
+{
+    [Fact]
+    public void create_with_correct_properties()
+    {
+        var slug = new Slug("my-post");
+        var visitorId = new VisitorId(Guid.NewGuid());
+        var viewedAt = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        var view = PageView.Create(slug, visitorId, viewedAt);
+
+        view.Id.Should().NotBeEmpty();
+        view.PostSlug.Should().Be(slug);
+        view.VisitorId.Should().Be(visitorId);
+        view.ViewedAtUtc.Should().Be(viewedAt);
+    }
+
+    [Fact]
+    public void generate_unique_ids()
+    {
+        var slug = new Slug("my-post");
+        var visitorId = new VisitorId(Guid.NewGuid());
+        var now = DateTime.UtcNow;
+
+        var view1 = PageView.Create(slug, visitorId, now);
+        var view2 = PageView.Create(slug, visitorId, now);
+
+        view1.Id.Should().NotBe(view2.Id);
+    }
+}

--- a/frontend/public/scripts/postcard-counts.js
+++ b/frontend/public/scripts/postcard-counts.js
@@ -25,6 +25,15 @@ function fetchPostCardCounts() {
         if (countEl) countEl.textContent = String(data.count ?? data);
       })
       .catch(function() {});
+
+    fetch(api + '/api/posts/' + slug + '/views/count')
+      .then(function(res) { return res.ok ? res.json() : null; })
+      .then(function(data) {
+        if (!data) return;
+        var countEl = card.querySelector('.postcard-view-count');
+        if (countEl) countEl.textContent = String(data.count ?? data);
+      })
+      .catch(function() {});
   });
 }
 fetchPostCardCounts();

--- a/frontend/src/components/PostCard.astro
+++ b/frontend/src/components/PostCard.astro
@@ -51,6 +51,14 @@ const formattedDate = new Date(date).toLocaleDateString('en-US', {
         </svg>
         <span class="postcard-comment-count">—</span>
       </span>
+      <span class="w-1 h-1 rounded-full bg-[var(--color-text-muted)]"></span>
+      <span class="postcard-views" data-slug={slug}>
+        <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <span class="postcard-view-count">—</span>
+      </span>
     </div>
 
     <!-- Title -->

--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -244,4 +244,27 @@ const canonicalUrl = new URL(`/blog/${post.slug}`, Astro.site).href;
   document.addEventListener('astro:after-swap', initScrollSpy);
 </script>
 
+<script define:vars={{ slug: post.slug }}>
+  function recordPageView() {
+    var key = 'viewed-' + slug;
+    if (sessionStorage.getItem(key)) return;
+
+    var apiBase = document.querySelector('meta[name="api-base"]');
+    if (!apiBase) return;
+    var api = apiBase.getAttribute('content');
+    var visitorId = window.__visitorId;
+    if (!visitorId) return;
+
+    fetch(api + '/api/posts/' + slug + '/views', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ visitorId: visitorId })
+    }).then(function() {
+      sessionStorage.setItem(key, '1');
+    }).catch(function() {});
+  }
+  recordPageView();
+  document.addEventListener('astro:after-swap', recordPageView);
+</script>
+
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Add `PageView` entity with surrogate Guid key (non-idempotent, unlike Likes)
- New endpoints: `POST /api/posts/{slug}/views` and `GET /api/posts/{slug}/views/count`
- Eye icon + view count displayed in PostCard alongside likes and comments
- Post detail page records view on load; `sessionStorage` prevents inflation on refresh

## Vertical slice
Domain → Repository → Use Case → API → Migration → Frontend (PostCard + detail page)

## Test plan
- [x] 2 domain tests: PageView creation and unique ID generation
- [x] 4 use case tests: RecordPageView and GetPageViewCount (happy path + not found)
- [x] E2E: record view → count increments → same visitor increments again (not idempotent) → 404 for missing post → 400 for invalid visitorId
- [x] All existing tests pass
- [x] Frontend builds successfully

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)