### PR TITLE
fix(frontend): polish view counter, fix tag slug routing, improve dev setup

### DIFF
--- a/backend/src/TacBlog.Api/Program.cs
+++ b/backend/src/TacBlog.Api/Program.cs
@@ -28,7 +28,7 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"));
 
 var allowedOrigins = builder.Environment.IsDevelopment()
-    ? new[] { "http://localhost:4321" }
+    ? new[] { "http://localhost:4321", "http://localhost:4322", "http://localhost:4323" }
     : new[] { "https://theaugmentedcraftsman.christianborrello.dev" };
 
 builder.Services.AddCors(options =>

--- a/frontend/src/components/PostCard.astro
+++ b/frontend/src/components/PostCard.astro
@@ -35,8 +35,20 @@ const formattedDate = new Date(date).toLocaleDateString('en-US', {
     <!-- Meta -->
     <div class="flex items-center gap-3 text-xs font-mono text-[var(--color-text-muted)]">
       <time datetime={date}>{formattedDate}</time>
+      {readingTime && (
+        <>
+          <span class="w-1 h-1 rounded-full bg-[var(--color-text-muted)]"></span>
+          <span>{readingTime}</span>
+        </>
+      )}
       <span class="w-1 h-1 rounded-full bg-[var(--color-text-muted)]"></span>
-      <span>{readingTime}</span>
+      <span class="postcard-views" data-slug={slug}>
+        <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <span class="postcard-view-count">—</span>
+      </span>
       <span class="w-1 h-1 rounded-full bg-[var(--color-text-muted)]"></span>
       <span class="postcard-likes" data-slug={slug}>
         <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
@@ -50,14 +62,6 @@ const formattedDate = new Date(date).toLocaleDateString('en-US', {
           <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
         </svg>
         <span class="postcard-comment-count">—</span>
-      </span>
-      <span class="w-1 h-1 rounded-full bg-[var(--color-text-muted)]"></span>
-      <span class="postcard-views" data-slug={slug}>
-        <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-          <circle cx="12" cy="12" r="3" />
-        </svg>
-        <span class="postcard-view-count">—</span>
       </span>
     </div>
 
@@ -80,7 +84,7 @@ const formattedDate = new Date(date).toLocaleDateString('en-US', {
     <!-- Tags -->
     <div class="flex flex-wrap gap-2 pt-2">
       {tags.map((tag) => (
-        <TagBadge tag={tag.name} color={tag.color} colorDark={tag.colorDark} />
+        <TagBadge tag={tag.name} slug={tag.slug} color={tag.color} colorDark={tag.colorDark} />
       ))}
     </div>
   </a>

--- a/frontend/src/components/TagBadge.astro
+++ b/frontend/src/components/TagBadge.astro
@@ -1,6 +1,7 @@
 ---
 interface Props {
   tag: string;
+  slug?: string;
   color?: string;
   colorDark?: string;
   count?: number;
@@ -8,9 +9,9 @@ interface Props {
   linked?: boolean;
 }
 
-const { tag, color, colorDark, count, size = 'sm', linked = false } = Astro.props;
+const { tag, slug: slugProp, color, colorDark, count, size = 'sm', linked = false } = Astro.props;
 
-const slug = tag.toLowerCase().replace(/\s+/g, '-');
+const slug = slugProp || tag.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
 
 const fallbackClass = 'bg-[var(--color-bg-surface)] text-[var(--color-text-muted)] border-[var(--color-border)]';
 

--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -69,7 +69,7 @@ const canonicalUrl = new URL(`/blog/${post.slug}`, Astro.site).href;
         {post.tags.length > 0 && (
           <div class="flex flex-wrap gap-2 mt-6">
             {post.tags.map((tag) => (
-              <TagBadge tag={tag.name} color={tag.color} colorDark={tag.colorDark} size="md" linked />
+              <TagBadge tag={tag.name} slug={tag.slug} color={tag.color} colorDark={tag.colorDark} size="md" linked />
             ))}
           </div>
         )}

--- a/frontend/src/pages/blog/index.astro
+++ b/frontend/src/pages/blog/index.astro
@@ -43,7 +43,7 @@ const allTags = (() => {
           All
         </a>
         {allTags.map(({ tag, count }) => (
-          <TagBadge tag={tag.name} color={tag.color} colorDark={tag.colorDark} count={count} linked />
+          <TagBadge tag={tag.name} slug={tag.slug} color={tag.color} colorDark={tag.colorDark} count={count} linked />
         ))}
       </div>
     </section>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -104,8 +104,8 @@ const topTags = (await fetchTags()).slice(0, 6);
         </a>
       </div>
       <div class="flex flex-wrap gap-3">
-        {topTags.map(({ name, color, colorDark, postCount }) => (
-          <TagBadge tag={name} color={color} colorDark={colorDark} count={postCount} size="md" linked />
+        {topTags.map(({ name, slug, color, colorDark, postCount }) => (
+          <TagBadge tag={name} slug={slug} color={color} colorDark={colorDark} count={postCount} size="md" linked />
         ))}
       </div>
     </section>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -595,14 +595,16 @@
 
 @layer components {
   .postcard-likes,
-  .postcard-comments {
+  .postcard-comments,
+  .postcard-views {
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
   }
 
   .postcard-likes svg,
-  .postcard-comments svg {
+  .postcard-comments svg,
+  .postcard-views svg {
     width: 12px;
     height: 12px;
     color: var(--color-text-muted);

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -m
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 BACKEND_PID=""
@@ -10,13 +11,13 @@ cleanup() {
     echo "Shutting down..."
 
     if [[ -n "$FRONTEND_PID" ]] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
-        kill "$FRONTEND_PID" 2>/dev/null
+        kill -- -"$FRONTEND_PID" 2>/dev/null || kill "$FRONTEND_PID" 2>/dev/null
         wait "$FRONTEND_PID" 2>/dev/null || true
         echo "Frontend stopped."
     fi
 
     if [[ -n "$BACKEND_PID" ]] && kill -0 "$BACKEND_PID" 2>/dev/null; then
-        kill "$BACKEND_PID" 2>/dev/null
+        kill -- -"$BACKEND_PID" 2>/dev/null || kill "$BACKEND_PID" 2>/dev/null
         wait "$BACKEND_PID" 2>/dev/null || true
         echo "Backend stopped."
     fi
@@ -24,7 +25,7 @@ cleanup() {
     echo "Done."
 }
 
-trap cleanup EXIT INT TERM
+trap cleanup EXIT INT TERM HUP
 
 echo "=== Starting backend (dotnet) ==="
 cd "$ROOT_DIR/backend"


### PR DESCRIPTION
## Summary
- Fix view counter icon not rendering (missing `.postcard-views` CSS)
- Reorder PostCard counters: date → readingTime → views → likes → comments
- Hide readingTime when empty (removes orphan dot separator)
- Fix tag routing: "Next.js" linked to `/tags/next.js` instead of `/tags/nextjs` — TagBadge now uses slug from API
- Add CORS origins for ports 4322/4323 in dev (Astro port increment)
- Fix `dev.sh` to kill process groups, preventing orphan processes

## Test plan
- [x] View counter icon visible with correct styling
- [x] Counter order matches: date → views → likes → comments
- [x] Clicking "Next.js" tag navigates to `/tags/nextjs` correctly
- [x] All other tag links verified working
- [x] Frontend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)